### PR TITLE
lock-manager: Add unit tests for behaviour not covered by storage testsuite

### DIFF
--- a/pkg/lock-manager/manager.go
+++ b/pkg/lock-manager/manager.go
@@ -149,9 +149,8 @@ func (lm *LockManager) Release(group, id string) error {
 	if lGroup == nil {
 		return errors.NewErrorUnknownGroup(group)
 	}
-	// No locks without id, so we don't need to bother storage here
 	if id == "" {
-		return nil
+		return errors.ErrorEmptyID{}
 	}
 
 	lGroup.RWLock.Lock()

--- a/pkg/lock-manager/manager_test.go
+++ b/pkg/lock-manager/manager_test.go
@@ -1,0 +1,137 @@
+package lockmanager
+
+import (
+	"os"
+	"reflect"
+	"testing"
+
+	"github.com/heathcliff26/fleetlock/pkg/lock-manager/storage/sqlite"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewManager(t *testing.T) {
+	tMatrix := []struct {
+		Name    string
+		Storage *StorageConfig
+		Result  struct {
+			groups  map[string]*lockGroup
+			storage string
+		}
+		Error string
+	}{
+		{
+			Name: "MemoryBackend",
+			Storage: &StorageConfig{
+				Type: "memory",
+			},
+			Result: struct {
+				groups  map[string]*lockGroup
+				storage string
+			}{
+				groups:  initGroups(NewDefaultGroups()),
+				storage: "*memory.MemoryBackend",
+			},
+			Error: "",
+		},
+		{
+			Name: "SQLiteBackend",
+			Storage: &StorageConfig{
+				Type: "sqlite",
+				SQLite: &sqlite.SQLiteConfig{
+					File: "test.db",
+				},
+			},
+			Result: struct {
+				groups  map[string]*lockGroup
+				storage string
+			}{
+				groups:  initGroups(NewDefaultGroups()),
+				storage: "*sqlite.SQLBackend",
+			},
+			Error: "",
+		},
+		{
+			Name: "ErrorNewSQLiteBackend",
+			Storage: &StorageConfig{
+				Type: "sqlite",
+				SQLite: &sqlite.SQLiteConfig{
+					File: "/not/a/valid/path/to/database",
+				},
+			},
+			Error: "sqlite3.Error",
+		},
+		{
+			Name: "UnknownStorageType",
+			Storage: &StorageConfig{
+				Type: "not-a-valid-type",
+			},
+			Error: "*errors.ErrorUnkownStorageType",
+		},
+	}
+	t.Cleanup(func() {
+		err := os.Remove("test.db")
+		if err != nil {
+			t.Logf("Failed to cleanup sqlite database file: %v", err)
+		}
+	})
+
+	for _, tCase := range tMatrix {
+		t.Run(tCase.Name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			lm, err := NewManager(NewDefaultGroups(), tCase.Storage)
+
+			if tCase.Error == "" {
+				assert.Nil(err)
+				if !assert.NotNil(lm) {
+					t.FailNow()
+				}
+				assert.Equal(tCase.Result.groups, lm.groups)
+				assert.Equal(tCase.Result.storage, reflect.TypeOf(lm.storage).String())
+			} else {
+				assert.Nil(lm)
+				assert.Equal(tCase.Error, reflect.TypeOf(err).String())
+			}
+		})
+	}
+}
+
+func TestReserve(t *testing.T) {
+	storageCfg := StorageConfig{
+		Type: "memory",
+	}
+	lm, err := NewManager(NewDefaultGroups(), &storageCfg)
+
+	assert := assert.New(t)
+
+	if !assert.Nil(err) {
+		t.FailNow()
+	}
+
+	ok, err := lm.Reserve("unknown", "somebody")
+	assert.False(ok)
+	assert.Equal("*errors.ErrorUnknownGroup", reflect.TypeOf(err).String())
+
+	ok, err = lm.Reserve("default", "")
+	assert.False(ok)
+	assert.Equal("errors.ErrorEmptyID", reflect.TypeOf(err).String())
+}
+
+func TestRelease(t *testing.T) {
+	storageCfg := StorageConfig{
+		Type: "memory",
+	}
+	lm, err := NewManager(NewDefaultGroups(), &storageCfg)
+
+	assert := assert.New(t)
+
+	if !assert.Nil(err) {
+		t.FailNow()
+	}
+
+	err = lm.Release("unknown", "somebody")
+	assert.Equal("*errors.ErrorUnknownGroup", reflect.TypeOf(err).String())
+
+	err = lm.Release("default", "")
+	assert.Equal("errors.ErrorEmptyID", reflect.TypeOf(err).String())
+}


### PR DESCRIPTION
Return error when calling release without id, as this is not a supported case.