### PR TITLE
storage/redis: Implement loadbalanced client

### DIFF
--- a/configs/example-config.yaml
+++ b/configs/example-config.yaml
@@ -30,6 +30,9 @@ storage:
   redis:
     # The address of the redis database
     address: "localhost:1234"
+    # (Optional) List of addresses when connectiong should be loadbalanced between active-active replicas.
+    addresses:
+      - ""
     # (Optional) Username for authentication
     username: ""
     # (Optional) Password for authentication

--- a/pkg/lock-manager/storage/redis/loadbalancer.go
+++ b/pkg/lock-manager/storage/redis/loadbalancer.go
@@ -1,0 +1,100 @@
+package redis
+
+import (
+	"context"
+	"net"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+const loadbalancerHealtchCheckPeriod = time.Second * 10
+
+type loadbalancer struct {
+	// List of addresses for redis endpoints
+	addrs []string
+	// Options for connecting to redis
+	options redis.Options
+	// Context to cancle health check
+	ctx    context.Context
+	cancel context.CancelFunc
+
+	selected int
+	rwlock   sync.RWMutex
+}
+
+// Create a new redis client with loadbalanced connections
+func NewRedisClientWithLoadbalancer(addrs []string, opt *redis.Options) (*redis.Client, *loadbalancer) {
+	lb := NewRedisLoadbalancer(addrs, *opt)
+	lb.PeriodicHealthCheck()
+	opt.Dialer = lb.Dial
+	return redis.NewClient(opt), lb
+}
+
+// Return a new loadbalancer for redis
+func NewRedisLoadbalancer(addrs []string, opt redis.Options) *loadbalancer {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	if opt.Network == "" {
+		opt.Network = "tcp"
+	}
+
+	return &loadbalancer{
+		addrs:   addrs,
+		options: opt,
+		ctx:     ctx,
+		cancel:  cancel,
+	}
+}
+
+// Determine the first healthy master node
+func (lb *loadbalancer) HealthCheck() {
+	for i, addr := range lb.addrs {
+		opt := lb.options
+		opt.Addr = addr
+		client := redis.NewClient(&opt)
+		defer client.Close()
+
+		res, err := client.Ping(context.Background()).Result()
+		if err != nil || res != "PONG" {
+			continue
+		}
+
+		res, err = client.Info(context.Background(), "replication").Result()
+		if err == nil || strings.Contains(res, "role:master") {
+			lb.rwlock.Lock()
+			defer lb.rwlock.Unlock()
+			lb.selected = i
+			break
+		}
+	}
+}
+
+// Starts go-routine that periodically runs a healthcheck in the background
+func (lb *loadbalancer) PeriodicHealthCheck() {
+	go lb.periodicHealthCheck()
+}
+
+func (lb *loadbalancer) periodicHealthCheck() {
+	for {
+		lb.HealthCheck()
+
+		select {
+		case <-lb.ctx.Done():
+			return
+		case <-time.After(loadbalancerHealtchCheckPeriod):
+		}
+	}
+}
+
+func (lb *loadbalancer) Dial(ctx context.Context, _ string, _ string) (net.Conn, error) {
+	lb.rwlock.RLock()
+	defer lb.rwlock.RUnlock()
+	return net.Dial(lb.options.Network, lb.addrs[lb.selected])
+}
+
+func (lb *loadbalancer) Close() {
+	lb.cancel()
+}

--- a/pkg/lock-manager/storage/redis/loadbalancer_test.go
+++ b/pkg/lock-manager/storage/redis/loadbalancer_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/alicebob/miniredis/v2"
+	"github.com/heathcliff26/fleetlock/tests/utils"
 	"github.com/redis/go-redis/v9"
 	"github.com/stretchr/testify/assert"
 )
@@ -26,6 +27,51 @@ func TestLoadbalancer(t *testing.T) {
 
 		res, err := client.Ping(context.Background()).Result()
 		if !assert.Nil(err, "Can reach client") || !assert.Equal("PONG", res, "Can reach client") {
+			t.FailNow()
+		}
+	})
+	t.Run("Failover", func(t *testing.T) {
+		if !utils.HasContainerRuntimer() {
+			t.Skip("Missing Container Runtime")
+		}
+
+		err := utils.ExecCRI("run", "--name", "fleetlock-redis-loadbalancer-failover-1", "-d", "--rm", "--net", "host", "docker.io/eqalpha/keydb:latest", "--port", "6379", "--active-replica", "yes", "--replicaof", "localhost", "6380")
+		if err != nil {
+			t.Fatalf("Failed to start test db: %v\n", err)
+		}
+		t.Cleanup(func() {
+			_ = utils.ExecCRI("stop", "fleetlock-redis-loadbalancer-failover-1")
+		})
+		err = utils.ExecCRI("run", "--name", "fleetlock-redis-loadbalancer-failover-2", "-d", "--rm", "--net", "host", "docker.io/eqalpha/keydb:latest", "--port", "6380", "--active-replica", "yes", "--replicaof", "localhost", "6379")
+		if err != nil {
+			t.Fatalf("Failed to start test db: %v\n", err)
+		}
+		t.Cleanup(func() {
+			_ = utils.ExecCRI("stop", "fleetlock-redis-loadbalancer-failover-2")
+		})
+
+		addrs := []string{"localhost:6379", "localhost:6380"}
+		client, lb := NewRedisClientWithLoadbalancer(addrs, &redis.Options{})
+		t.Cleanup(func() {
+			lb.Close()
+			client.Close()
+		})
+
+		assert := assert.New(t)
+
+		assert.Equal(0, lb.selected, "Should have currently the first client selected")
+
+		err = utils.ExecCRI("stop", "fleetlock-redis-loadbalancer-failover-1")
+		if err != nil {
+			t.Fatalf("Failed to stop keydb instance: %v\n", err)
+		}
+		lb.HealthCheck()
+
+		if !assert.Equal(1, lb.selected, "Should have failed over") {
+			t.FailNow()
+		}
+		res, err := client.Ping(context.Background()).Result()
+		if !assert.Nil(err, "Should have failed over") || !assert.Equal("PONG", res, "Should have failed over") {
 			t.FailNow()
 		}
 	})

--- a/pkg/lock-manager/storage/redis/loadbalancer_test.go
+++ b/pkg/lock-manager/storage/redis/loadbalancer_test.go
@@ -1,0 +1,32 @@
+package redis
+
+import (
+	"context"
+	"testing"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLoadbalancer(t *testing.T) {
+	t.Run("Basic", func(t *testing.T) {
+		mr1 := miniredis.RunT(t)
+		mr2 := miniredis.RunT(t)
+
+		addrs := []string{mr1.Addr(), mr2.Addr()}
+
+		client, lb := NewRedisClientWithLoadbalancer(addrs, &redis.Options{})
+		t.Cleanup(func() {
+			lb.Close()
+			client.Close()
+		})
+
+		assert := assert.New(t)
+
+		res, err := client.Ping(context.Background()).Result()
+		if !assert.Nil(err, "Can reach client") || !assert.Equal("PONG", res, "Can reach client") {
+			t.FailNow()
+		}
+	})
+}

--- a/tests/utils/container.go
+++ b/tests/utils/container.go
@@ -1,0 +1,43 @@
+package utils
+
+import (
+	"fmt"
+	"os/exec"
+)
+
+var (
+	containerRuntime string
+	initialized      = false
+)
+
+func findContainerRuntime() string {
+	for _, cmd := range []string{"docker", "podman"} {
+		path, err := exec.LookPath(cmd)
+		if err != nil {
+			continue
+		}
+		err = exec.Command(path, "ps").Run()
+		if err == nil {
+			fmt.Printf("Found container runtime %s, path=%s\n", cmd, path)
+			return path
+		}
+	}
+	fmt.Println("Did not find any container runtimes")
+	return ""
+}
+
+func HasContainerRuntimer() bool {
+	if !initialized {
+		containerRuntime = findContainerRuntime()
+		initialized = true
+	}
+	return containerRuntime != ""
+}
+
+func ExecCRI(args ...string) error {
+	if !initialized {
+		containerRuntime = findContainerRuntime()
+		initialized = true
+	}
+	return exec.Command(containerRuntime, args...).Run()
+}


### PR DESCRIPTION
Add option to use client that is loadbalanced to connect to clients that are
active-active replicated.

Add utility to run container commands during tests when a runtime is available.