### PR TITLE
CI: Run unit-tests before build

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,10 +36,14 @@ jobs:
   lint:
     uses: heathcliff26/ci/.github/workflows/golang-lint.yaml@main
 
+  unit-tests:
+    uses: heathcliff26/ci/.github/workflows/golang-unit-tests.yaml@main
+
   build:
     uses: heathcliff26/ci/.github/workflows/build-container.yaml@main
     needs:
       - lint
+      - unit-tests
     permissions:
       contents: read
       packages: write

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,29 +22,13 @@ RUN --mount=type=bind,target=/app/.git,source=.git GOOS=linux GOARCH="${TARGETAR
 ###############################################################################
 
 ###############################################################################
-# BEGIN test-stage
-# Run the tests in the container
-FROM docker.io/library/golang:1.22.2@sha256:d5302d40dc5fbbf38ec472d1848a9d2391a13f93293a6a5b0b87c99dc0eaa6ae AS test-stage
-
-WORKDIR /app
-
-COPY --from=build-stage /app /app
-COPY tests ./tests
-
-RUN go test -v ./...
-
-#
-# END test-stage
-###############################################################################
-
-###############################################################################
 # BEGIN final-stage
 # Create final docker image
 FROM scratch AS final-stage
 
 WORKDIR /
 
-COPY --from=test-stage /app/bin/fleetlock /
+COPY --from=build-stage /app/bin/fleetlock /
 
 USER 1001
 


### PR DESCRIPTION
Running the unit tests on the github runner enables running tests that need access to a container runtime.
Do not run unit-tests inside container build.