### PR TITLE
storage/redis: Fix wrong condition for HasLock

### DIFF
--- a/pkg/lock-manager/storage/redis/storage.go
+++ b/pkg/lock-manager/storage/redis/storage.go
@@ -128,7 +128,7 @@ func (r *RedisBackend) HasLock(group string, id string) (bool, error) {
 	ctx := context.Background()
 
 	count, err := r.client.Exists(ctx, key).Result()
-	return count == 1 || err != nil, err
+	return count == 1 && err == nil, err
 }
 
 // Calls all necessary finalization if necessary


### PR DESCRIPTION
HasLock should return false when an error occured.