### PR TITLE
storage/sqlite3: Run test databases in memory

### DIFF
--- a/pkg/lock-manager/manager_test.go
+++ b/pkg/lock-manager/manager_test.go
@@ -1,7 +1,6 @@
 package lockmanager
 
 import (
-	"os"
 	"reflect"
 	"testing"
 
@@ -40,7 +39,7 @@ func TestNewManager(t *testing.T) {
 			Storage: &StorageConfig{
 				Type: "sqlite",
 				SQLite: &sql.SQLiteConfig{
-					File: "test.db",
+					File: "file:test.db?mode=memory",
 				},
 			},
 			Result: result{
@@ -113,12 +112,6 @@ func TestNewManager(t *testing.T) {
 			Error: "*errors.ErrorUnkownStorageType",
 		},
 	}
-	t.Cleanup(func() {
-		err := os.Remove("test.db")
-		if err != nil {
-			t.Logf("Failed to cleanup sqlite database file: %v", err)
-		}
-	})
 
 	for _, tCase := range tMatrix {
 		t.Run(tCase.Name, func(t *testing.T) {

--- a/tests/storage/sqlite_test.go
+++ b/tests/storage/sqlite_test.go
@@ -1,7 +1,6 @@
 package storage
 
 import (
-	"os"
 	"testing"
 
 	"github.com/heathcliff26/fleetlock/pkg/lock-manager/storage/sql"
@@ -9,18 +8,12 @@ import (
 
 func TestSQLiteBackend(t *testing.T) {
 	cfg := sql.SQLiteConfig{
-		File: "test.db",
+		File: "file:test.db?mode=memory",
 	}
 	storage, err := sql.NewSQLiteBackend(&cfg)
 	if err != nil {
 		t.Fatalf("Failed to create storage backend: %v", err)
 	}
-	t.Cleanup(func() {
-		err = os.Remove("test.db")
-		if err != nil {
-			t.Logf("Failed to cleanup sqlite database file: %v", err)
-		}
-	})
 
 	RunLockManagerTestsuiteWithStorage(t, storage)
 }


### PR DESCRIPTION
Run sqlite databases in memory only to avoid leaked files after tests, as well as problems when running on nfs/cifs/smb storage.