### PR TITLE
Add functionality to expand config file from enviroment variables

### DIFF
--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -25,12 +25,19 @@ func NewRootCommand() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			run(cmd, cfg)
+
+			env, err := cmd.Flags().GetBool("env")
+			if err != nil {
+				return err
+			}
+
+			run(cmd, cfg, env)
 			return nil
 		},
 	}
 
 	rootCmd.Flags().StringP("config", "c", "", "Path to config file")
+	rootCmd.Flags().Bool("env", false, "Expand enviroment variables in config file")
 	rootCmd.AddCommand(
 		version.NewCommand(),
 	)
@@ -46,8 +53,8 @@ func Execute() {
 	}
 }
 
-func run(cmd *cobra.Command, configPath string) {
-	cfg, err := config.LoadConfig(configPath)
+func run(cmd *cobra.Command, configPath string, env bool) {
+	cfg, err := config.LoadConfig(configPath, env)
 	if err != nil {
 		exitError(cmd, err)
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -61,7 +61,7 @@ func DefaultConfig() *Config {
 // Loads the config from the given path.
 // When path is empty, returns default config.
 // Returns error when the given config is invalid.
-func LoadConfig(path string) (*Config, error) {
+func LoadConfig(path string, env bool) (*Config, error) {
 	c := DefaultConfig()
 
 	if path == "" {
@@ -72,6 +72,10 @@ func LoadConfig(path string) (*Config, error) {
 	f, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
+	}
+
+	if env {
+		f = []byte(os.ExpandEnv(string(f)))
 	}
 
 	err = yaml.Unmarshal(f, &c)

--- a/pkg/config/testdata/env-substitution.yaml
+++ b/pkg/config/testdata/env-substitution.yaml
@@ -1,0 +1,7 @@
+storage:
+  type: redis
+  redis:
+    address: "localhost:4321"
+    username: "${FLEETLOCK_REDIS_USERNAME}"
+    password: "${FLEETLOCK_REDIS_PASSWORD}"
+    db: 5


### PR DESCRIPTION
Add flag `--env` that exands the configuration file from the enviroment. This can be used to insert Passwords and other secrets without storing them insecurely in the file.