### PR TITLE
Implement node draining before acknowledging reservations

### DIFF
--- a/examples/example-config.yaml
+++ b/examples/example-config.yaml
@@ -2,6 +2,10 @@
 # The level of loggin output
 logLevel: info
 
+# The path to the kubeconfig file. Used for draining nodes and the kubernetes storage option if used.
+# Falls back to in-cluster serviceaccount if left empty (recommended)
+kubeconfig: ""
+
 server:
   # The listen address of the server in the form of <ip>:<port>
   listen: ":8080"
@@ -91,8 +95,8 @@ storage:
     # (Optional) Private key of client certificate for authentication
     key: ""
   kubernetes:
-    # (Optional) Path to kubeconfig file, default uses in-cluster serviceaccount
-    kubeconfig: ""
+    # The kubeconfig setting is inherited from the global setting
+
     # (Optional) Namespace to create leases in, default reads it from file inside pod or defaults to fleetlock
     namespace: ""
 

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/heathcliff26/fleetlock/pkg/config"
+	"github.com/heathcliff26/fleetlock/pkg/k8s"
 	"github.com/heathcliff26/fleetlock/pkg/server"
 	"github.com/heathcliff26/fleetlock/pkg/version"
 	"github.com/spf13/cobra"
@@ -59,7 +60,12 @@ func run(cmd *cobra.Command, configPath string, env bool) {
 		exitError(cmd, fmt.Errorf("failed to load configuration: %w", err))
 	}
 
-	s, err := server.NewServer(cfg.Server, cfg.Groups, cfg.Storage)
+	k8s, err := k8s.NewClient(cfg.Kubeconfig)
+	if err != nil {
+		exitError(cmd, fmt.Errorf("failed to create kubernetes client: %w", err))
+	}
+
+	s, err := server.NewServer(cfg.Server, cfg.Groups, cfg.Storage, k8s)
 	if err != nil {
 		exitError(cmd, fmt.Errorf("failed to create server: %w", err))
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -27,10 +27,11 @@ func init() {
 }
 
 type Config struct {
-	LogLevel string                    `yaml:"logLevel,omitempty"`
-	Server   *server.ServerConfig      `yaml:"server,omitempty"`
-	Storage  lockmanager.StorageConfig `yaml:"storage,omitempty"`
-	Groups   lockmanager.Groups        `yaml:"groups,omitempty"`
+	LogLevel   string                    `yaml:"logLevel,omitempty"`
+	Kubeconfig string                    `yaml:"kubeconfig,omitempty"`
+	Server     *server.ServerConfig      `yaml:"server,omitempty"`
+	Storage    lockmanager.StorageConfig `yaml:"storage,omitempty"`
+	Groups     lockmanager.Groups        `yaml:"groups,omitempty"`
 }
 
 // Parse a given string and set the resulting log level
@@ -98,6 +99,8 @@ func (c *Config) Defaults() {
 	if c.Groups == nil {
 		c.Groups = lockmanager.NewDefaultGroups()
 	}
+
+	c.Storage.Kubernetes.Kubeconfig = c.Kubeconfig
 }
 
 func (c *Config) Validate() error {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	lockmanager "github.com/heathcliff26/fleetlock/pkg/lock-manager"
+	"github.com/heathcliff26/fleetlock/pkg/lock-manager/storage/kubernetes"
 	"github.com/heathcliff26/fleetlock/pkg/lock-manager/storage/redis"
 	"github.com/heathcliff26/fleetlock/pkg/lock-manager/storage/sql"
 	"github.com/heathcliff26/fleetlock/pkg/server"
@@ -50,6 +51,17 @@ func TestValidConfigs(t *testing.T) {
 	defaultConfig := DefaultConfig()
 	defaultConfig.Defaults()
 
+	cfgKubernetes := DefaultConfig()
+	cfgKubernetes.Defaults()
+	cfgKubernetes.Storage = lockmanager.StorageConfig{
+		Type: "kubernetes",
+		Kubernetes: kubernetes.KubernetesConfig{
+			Namespace:  "test",
+			Kubeconfig: "some-path",
+		},
+	}
+	cfgKubernetes.Kubeconfig = "some-path"
+
 	tMatrix := []struct {
 		Name, Path string
 		Result     *Config
@@ -73,6 +85,11 @@ func TestValidConfigs(t *testing.T) {
 			Name:   "NoConfig",
 			Path:   "",
 			Result: defaultConfig,
+		},
+		{
+			Name:   "ValidConfig3",
+			Path:   "testdata/valid-config-kubernetes.yaml",
+			Result: cfgKubernetes,
 		},
 	}
 

--- a/pkg/config/testdata/valid-config-kubernetes.yaml
+++ b/pkg/config/testdata/valid-config-kubernetes.yaml
@@ -1,0 +1,6 @@
+---
+storage:
+  type: kubernetes
+  kubernetes:
+    namespace: "test"
+kubeconfig: "some-path"

--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -1,0 +1,194 @@
+package k8s
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/heathcliff26/fleetlock/pkg/k8s/utils"
+	systemdutils "github.com/heathcliff26/fleetlock/pkg/systemd-utils"
+
+	coordv1 "k8s.io/api/coordination/v1"
+	v1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/rest"
+)
+
+type Client struct {
+	client    kubernetes.Interface
+	namespace string
+}
+
+// Create a new kubernetes client, defaults to in-cluster if no kubeconfig is provided
+func NewClient(kubeconfig string) (*Client, error) {
+	client, err := utils.CreateNewClientset(kubeconfig)
+	if err == rest.ErrNotInCluster {
+		return nil, nil
+	} else if err != nil {
+		return nil, err
+	}
+
+	ns, err := utils.GetNamespace()
+	if err != nil {
+		return nil, err
+	}
+
+	return &Client{
+		client:    client,
+		namespace: ns,
+	}, nil
+}
+
+// Create a test client with a fake kubernetes clientset
+func NewFakeClient() (*Client, *fake.Clientset) {
+	fakeclient := fake.NewSimpleClientset()
+	return &Client{
+		client:    fakeclient,
+		namespace: "fleetlock",
+	}, fakeclient
+}
+
+// Drain a node from all pods and set it to unschedulable.
+// Status will be tracked in lease, only one drain will be run at a time.
+func (c *Client) DrainNode(node string) error {
+	lease, err := c.client.CoordinationV1().Leases(c.namespace).Get(context.TODO(), drainLeaseName(node), metav1.GetOptions{})
+	if errors.IsNotFound(err) {
+		lease = &coordv1.Lease{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: c.namespace,
+				Name:      drainLeaseName(node),
+			},
+			Spec: coordv1.LeaseSpec{
+				HolderIdentity:       utils.Pointer("draining"),
+				LeaseDurationSeconds: utils.Pointer(int32(300)),
+				AcquireTime:          &metav1.MicroTime{Time: time.Now()},
+			},
+		}
+
+		lease, err = c.client.CoordinationV1().Leases(c.namespace).Create(context.TODO(), lease, metav1.CreateOptions{})
+		if err != nil {
+			return err
+		}
+	} else if err != nil {
+		return err
+	} else if lease.Spec.AcquireTime != nil && time.Now().After(lease.Spec.AcquireTime.Time.Add(5*time.Minute)) {
+		lease.Spec.AcquireTime = &metav1.MicroTime{Time: time.Now()}
+		lease, err = c.client.CoordinationV1().Leases(c.namespace).Update(context.TODO(), lease, metav1.UpdateOptions{})
+		if err != nil {
+			return err
+		}
+	} else {
+		return NewErrorDrainIsLocked()
+	}
+
+	err = c.drainNode(node)
+	if err != nil {
+		return err
+	}
+
+	_, err = c.client.CoordinationV1().Leases(c.namespace).Patch(context.TODO(), lease.GetName(), types.MergePatchType, []byte("{\"spec\":{\"holderIdentity\":\"done\"}}"), metav1.PatchOptions{})
+	return err
+}
+
+// Drain a node of all pods, skipping daemonsets
+func (c *Client) drainNode(node string) error {
+	_, err := c.client.CoreV1().Nodes().Patch(context.TODO(), node, types.MergePatchType, nodeUnschedulablePatch(true), metav1.PatchOptions{})
+	if err != nil {
+		return err
+	}
+
+	pods, err := c.client.CoreV1().Pods(v1.NamespaceAll).List(context.TODO(), metav1.ListOptions{
+		FieldSelector: fields.SelectorFromSet(fields.Set{"spec.nodeName": node}).String(),
+	})
+	if err != nil {
+		return err
+	}
+
+	var returnError error
+	for _, pod := range pods.Items {
+		// Skip mirror pods
+		if _, ok := pod.ObjectMeta.Annotations[v1.MirrorPodAnnotationKey]; ok {
+			continue
+		}
+		// Skip daemonsets
+		controller := metav1.GetControllerOf(&pod)
+		if controller != nil && controller.Kind == "DaemonSet" {
+			continue
+		}
+
+		err = c.client.PolicyV1().Evictions(pod.GetNamespace()).Evict(context.TODO(), &policyv1.Eviction{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "policy/v1",
+				Kind:       "Eviction",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      pod.GetName(),
+				Namespace: pod.GetNamespace(),
+			},
+			DeleteOptions: metav1.NewDeleteOptions(*pod.Spec.TerminationGracePeriodSeconds),
+		})
+		if err != nil {
+			slog.Info("Failed to evict pod", "err", err, slog.String("node", node), slog.String("pod", pod.GetName()), slog.String("namespace", pod.GetNamespace()))
+			returnError = NewErrorFailedToEvictAllPods()
+			continue
+		}
+		slog.Info("Evicted pod", slog.String("node", node), slog.String("pod", pod.GetName()), slog.String("namespace", pod.GetNamespace()))
+	}
+
+	return returnError
+}
+
+// Find the node in the cluster with the matching machine id
+func (c *Client) FindNodeByZincatiID(zincatiID string) (string, error) {
+	nodes, err := c.client.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		return "", err
+	}
+
+	for _, node := range nodes.Items {
+		machineID := node.Status.NodeInfo.MachineID
+		appID, err := systemdutils.ZincatiMachineID(machineID)
+		if err != nil {
+			return "", err
+		}
+
+		if appID == zincatiID {
+			slog.Info("Matched node with zincati app id", slog.String("node", node.GetName()), slog.String("appid", zincatiID))
+			return node.Name, nil
+		}
+	}
+
+	return "", nil
+}
+
+// Uncordon a node
+func (c *Client) UncordonNode(node string) error {
+	_, err := c.client.CoreV1().Nodes().Patch(context.TODO(), node, types.MergePatchType, nodeUnschedulablePatch(false), metav1.PatchOptions{})
+	if err != nil {
+		return err
+	}
+	err = c.client.CoordinationV1().Leases(c.namespace).Delete(context.TODO(), drainLeaseName(node), metav1.DeleteOptions{})
+	if errors.IsNotFound(err) {
+		return nil
+	} else {
+		return err
+	}
+}
+
+// Check if a node has been drained
+func (c *Client) IsDrained(node string) (bool, error) {
+	lease, err := c.client.CoordinationV1().Leases(c.namespace).Get(context.TODO(), drainLeaseName(node), metav1.GetOptions{})
+	if errors.IsNotFound(err) {
+		return false, nil
+	} else if err != nil {
+		return false, err
+	}
+
+	return *lease.Spec.HolderIdentity == "done", nil
+}

--- a/pkg/k8s/client_test.go
+++ b/pkg/k8s/client_test.go
@@ -1,0 +1,265 @@
+package k8s
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/heathcliff26/fleetlock/pkg/k8s/utils"
+	"github.com/stretchr/testify/assert"
+	coordv1 "k8s.io/api/coordination/v1"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+const (
+	testNodeZincatiID = "35ba2101ae3f4d45b96e9c51f461bbff"
+	testNodeMachineID = "dfd7882acda64c34aca76193c46f5d4e"
+	testNodeName      = "Node1"
+	testNamespace     = "fleetlock"
+	testPodName       = "Pod1"
+)
+
+func initTestCluster(client *fake.Clientset) {
+	testNode := &v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: testNodeName,
+		},
+		Status: v1.NodeStatus{
+			NodeInfo: v1.NodeSystemInfo{MachineID: testNodeMachineID},
+		},
+	}
+	_, _ = client.CoreV1().Nodes().Create(context.TODO(), testNode, metav1.CreateOptions{})
+
+	testNS := &v1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: testNamespace,
+		},
+	}
+	_, _ = client.CoreV1().Namespaces().Create(context.TODO(), testNS, metav1.CreateOptions{})
+
+	testPod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testPodName,
+			Namespace: testNamespace,
+		},
+		Spec: v1.PodSpec{
+			NodeName:                      testNodeName,
+			TerminationGracePeriodSeconds: utils.Pointer(int64(1)),
+		},
+	}
+	_, _ = client.CoreV1().Pods(testNamespace).Create(context.TODO(), testPod, metav1.CreateOptions{})
+}
+
+func TestNewClient(t *testing.T) {
+	t.Run("NotInCluster", func(t *testing.T) {
+		c, err := NewClient("")
+		assert.Nil(t, c, "Should not return a client")
+		assert.Nil(t, err, "Should not return an error if not in cluster and no kubeconfig provided")
+	})
+	t.Run("KubeconfigNotFound", func(t *testing.T) {
+		c, err := NewClient("not-a-file")
+		assert.Nil(t, c, "Should not return a client")
+		assert.Error(t, err, "Should return an error if it can't find a kubeconfig")
+	})
+	t.Run("Kubeconfig", func(t *testing.T) {
+		c, err := NewClient("testdata/kubeconfig")
+		assert.Nil(t, err, "Should not return an error")
+		if !assert.NotNil(t, c, "Should return a client") {
+			t.FailNow()
+		}
+		assert.Equal(t, "fleetlock", c.namespace)
+	})
+}
+
+func TestDrainNode(t *testing.T) {
+	t.Run("NoLease", func(t *testing.T) {
+		c, client := NewFakeClient()
+		initTestCluster(client)
+
+		err := c.DrainNode(testNodeName)
+
+		assert := assert.New(t)
+
+		if !assert.Nilf(err, "Should not throw an error: %v", err) {
+			t.FailNow()
+		}
+
+		node, _ := client.CoreV1().Nodes().Get(context.TODO(), testNodeName, metav1.GetOptions{})
+		assert.True(node.Spec.Unschedulable, "Node should be unscheduable")
+
+		lease, _ := client.CoordinationV1().Leases(testNamespace).Get(context.TODO(), drainLeaseName(testNodeName), metav1.GetOptions{})
+		assert.Equal(utils.Pointer("done"), lease.Spec.HolderIdentity, "Lease should indicate node is drained")
+		assert.Equal(utils.Pointer(int32(300)), lease.Spec.LeaseDurationSeconds, "LeaseDurationSeconds should be set")
+		assert.Equal(time.Now().Round(time.Second), lease.Spec.AcquireTime.Time.Round(time.Second), "AcquireTime should be now")
+	})
+	t.Run("LeaseValid", func(t *testing.T) {
+		c, client := NewFakeClient()
+		initTestCluster(client)
+
+		lease := &coordv1.Lease{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: c.namespace,
+				Name:      drainLeaseName(testNodeName),
+			},
+			Spec: coordv1.LeaseSpec{
+				HolderIdentity:       utils.Pointer("draining"),
+				LeaseDurationSeconds: utils.Pointer(int32(300)),
+				AcquireTime:          &metav1.MicroTime{Time: time.Now()},
+			},
+		}
+		_, _ = client.CoordinationV1().Leases(testNamespace).Create(context.TODO(), lease, metav1.CreateOptions{})
+
+		err := c.DrainNode(testNodeName)
+		assert.Equal(t, NewErrorDrainIsLocked(), err, "Should return an error signaling that a drain is already in progress")
+	})
+	t.Run("LeaseExpired", func(t *testing.T) {
+		c, client := NewFakeClient()
+		initTestCluster(client)
+
+		lease := &coordv1.Lease{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: c.namespace,
+				Name:      drainLeaseName(testNodeName),
+			},
+			Spec: coordv1.LeaseSpec{
+				HolderIdentity:       utils.Pointer("draining"),
+				LeaseDurationSeconds: utils.Pointer(int32(300)),
+				AcquireTime:          &metav1.MicroTime{Time: time.Now().Add(-6 * time.Minute)},
+			},
+		}
+		_, _ = client.CoordinationV1().Leases(testNamespace).Create(context.TODO(), lease, metav1.CreateOptions{})
+
+		err := c.DrainNode(testNodeName)
+
+		assert := assert.New(t)
+
+		if !assert.Nilf(err, "Should not throw an error: %v", err) {
+			t.FailNow()
+		}
+
+		node, _ := client.CoreV1().Nodes().Get(context.TODO(), testNodeName, metav1.GetOptions{})
+		assert.True(node.Spec.Unschedulable, "Node should be unscheduable")
+
+		lease, _ = client.CoordinationV1().Leases(testNamespace).Get(context.TODO(), drainLeaseName(testNodeName), metav1.GetOptions{})
+		assert.Equal(utils.Pointer("done"), lease.Spec.HolderIdentity, "Lease should indicate node is drained")
+		assert.Equal(time.Now().Round(time.Second), lease.Spec.AcquireTime.Time.Round(time.Second), "AcquireTime should be now")
+	})
+}
+
+func TestFindNodeByZincatiID(t *testing.T) {
+	c, client := NewFakeClient()
+	initTestCluster(client)
+
+	node, err := c.FindNodeByZincatiID(testNodeZincatiID)
+
+	assert := assert.New(t)
+
+	assert.Equal(testNodeName, node, "Should have found correct node")
+	assert.Nil(err, "Should have found correct node")
+
+	node, err = c.FindNodeByZincatiID("abcdef123456789")
+	assert.Equal("", node, "Should return an empty string if no node has been found")
+	assert.Nil(err, "Should not return an error when no node has been found")
+}
+
+func TestUncordonNode(t *testing.T) {
+	c, client := NewFakeClient()
+	initTestCluster(client)
+
+	node, _ := client.CoreV1().Nodes().Get(context.TODO(), testNodeName, metav1.GetOptions{})
+	node.Spec.Unschedulable = true
+	_, _ = client.CoreV1().Nodes().Update(context.TODO(), node, metav1.UpdateOptions{})
+	lease := &coordv1.Lease{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: c.namespace,
+			Name:      drainLeaseName(testNodeName),
+		},
+		Spec: coordv1.LeaseSpec{
+			HolderIdentity:       utils.Pointer("done"),
+			LeaseDurationSeconds: utils.Pointer(int32(300)),
+			AcquireTime:          &metav1.MicroTime{Time: time.Now()},
+		},
+	}
+	_, _ = client.CoordinationV1().Leases(testNamespace).Create(context.TODO(), lease, metav1.CreateOptions{})
+
+	err := c.UncordonNode(testNodeName)
+
+	assert := assert.New(t)
+
+	assert.Nil(err, "Should not return an error")
+
+	_, err = client.CoordinationV1().Leases(testNamespace).Get(context.TODO(), drainLeaseName(testNodeName), metav1.GetOptions{})
+	assert.True(errors.IsNotFound(err), "Lease should be deleted")
+
+	node, _ = client.CoreV1().Nodes().Get(context.TODO(), testNodeName, metav1.GetOptions{})
+	assert.False(node.Spec.Unschedulable, "Node should be schedulable")
+
+	err = c.UncordonNode(testNodeName)
+	assert.Nil(err, "Should not return an error")
+}
+
+func TestIsDrained(t *testing.T) {
+	t.Run("NoLease", func(t *testing.T) {
+		c, client := NewFakeClient()
+		initTestCluster(client)
+
+		res, err := c.IsDrained(testNodeName)
+
+		assert := assert.New(t)
+
+		assert.Nil(err, "Should not return an error")
+		assert.False(res, "Should return false")
+	})
+	t.Run("LeaseDone", func(t *testing.T) {
+		c, client := NewFakeClient()
+		initTestCluster(client)
+
+		lease := &coordv1.Lease{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: c.namespace,
+				Name:      drainLeaseName(testNodeName),
+			},
+			Spec: coordv1.LeaseSpec{
+				HolderIdentity:       utils.Pointer("done"),
+				LeaseDurationSeconds: utils.Pointer(int32(300)),
+				AcquireTime:          &metav1.MicroTime{Time: time.Now()},
+			},
+		}
+		_, _ = client.CoordinationV1().Leases(testNamespace).Create(context.TODO(), lease, metav1.CreateOptions{})
+
+		res, err := c.IsDrained(testNodeName)
+
+		assert := assert.New(t)
+
+		assert.Nil(err, "Should not return an error")
+		assert.True(res, "Should return true")
+	})
+	t.Run("LeaseDraining", func(t *testing.T) {
+		c, client := NewFakeClient()
+		initTestCluster(client)
+
+		lease := &coordv1.Lease{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: c.namespace,
+				Name:      drainLeaseName(testNodeName),
+			},
+			Spec: coordv1.LeaseSpec{
+				HolderIdentity:       utils.Pointer("draining"),
+				LeaseDurationSeconds: utils.Pointer(int32(300)),
+				AcquireTime:          &metav1.MicroTime{Time: time.Now()},
+			},
+		}
+		_, _ = client.CoordinationV1().Leases(testNamespace).Create(context.TODO(), lease, metav1.CreateOptions{})
+
+		res, err := c.IsDrained(testNodeName)
+
+		assert := assert.New(t)
+
+		assert.Nil(err, "Should not return an error")
+		assert.False(res, "Should return false")
+	})
+
+}

--- a/pkg/k8s/errors.go
+++ b/pkg/k8s/errors.go
@@ -1,0 +1,21 @@
+package k8s
+
+type ErrorFailedToEvictAllPods struct{}
+
+func NewErrorFailedToEvictAllPods() error {
+	return ErrorFailedToEvictAllPods{}
+}
+
+func (e ErrorFailedToEvictAllPods) Error() string {
+	return "Failed to evict all pods from node"
+}
+
+type ErrorDrainIsLocked struct{}
+
+func NewErrorDrainIsLocked() error {
+	return ErrorDrainIsLocked{}
+}
+
+func (e ErrorDrainIsLocked) Error() string {
+	return "Can't drain node, as another drain is already in progress"
+}

--- a/pkg/k8s/testdata/kubeconfig
+++ b/pkg/k8s/testdata/kubeconfig
@@ -1,0 +1,16 @@
+apiVersion: v1
+clusters:
+- cluster:
+    server: https://example.com:6443
+  name: default
+contexts:
+- context:
+    cluster: default
+    namespace: fleetlock
+    user: default
+  name: default
+current-context: default
+kind: Config
+preferences: {}
+users:
+- name: default

--- a/pkg/k8s/utils.go
+++ b/pkg/k8s/utils.go
@@ -1,0 +1,13 @@
+package k8s
+
+import (
+	"fmt"
+)
+
+func drainLeaseName(id string) string {
+	return fmt.Sprintf("fleetlock-drain-%s", id)
+}
+
+func nodeUnschedulablePatch(desired bool) []byte {
+	return []byte(fmt.Sprintf("{\"spec\":{\"unschedulable\":%t}}", desired))
+}

--- a/pkg/k8s/utils/utils.go
+++ b/pkg/k8s/utils/utils.go
@@ -5,12 +5,17 @@ import (
 	"fmt"
 	"os"
 	"strings"
+
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
 )
 
 var serviceAccountNamespaceFile = "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
 
 const namespaceFleetlock = "fleetlock"
 
+// Read the namespace from the inserted serviceaccount file. Fallback to default if the file does not exist.
 func GetNamespace() (string, error) {
 	data, err := os.ReadFile(serviceAccountNamespaceFile)
 	if err != nil {
@@ -26,4 +31,25 @@ func GetNamespace() (string, error) {
 		return "", NewErrorGetNamespace(serviceAccountNamespaceFile, fmt.Errorf("file was empty"))
 	}
 	return ns, nil
+}
+
+// Create a new kubernetes clientset from the provided kubeconfig. Default to in-cluster if none is provided.
+func CreateNewClientset(kubeconfig string) (kubernetes.Interface, error) {
+	var config *rest.Config
+	var err error
+	if kubeconfig == "" {
+		config, err = rest.InClusterConfig()
+	} else {
+		config, err = clientcmd.BuildConfigFromFlags("", kubeconfig)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	return kubernetes.NewForConfig(config)
+}
+
+// Return a pointer to the variable value
+func Pointer[T any](v T) *T {
+	return &v
 }

--- a/pkg/k8s/utils/utils_test.go
+++ b/pkg/k8s/utils/utils_test.go
@@ -68,3 +68,10 @@ func TestGetNamespace(t *testing.T) {
 		assert.Equal("", ns)
 	})
 }
+
+func TestPointer(t *testing.T) {
+	s := "test"
+	p := Pointer(s)
+	assert.Equal(t, &s, p, "Should contain the same string")
+	assert.NotSame(t, s, p, "Should not be the same")
+}

--- a/pkg/lock-manager/manager_test.go
+++ b/pkg/lock-manager/manager_test.go
@@ -122,7 +122,7 @@ func TestNewManager(t *testing.T) {
 				Type:       "kubernetes",
 				Kubernetes: kubernetes.KubernetesConfig{},
 			},
-			Error: "invalid configuration: no configuration has been provided, try setting KUBERNETES_MASTER environment variable",
+			Error: "unable to load in-cluster configuration",
 		},
 		{
 			Name: "UnknownStorageType",

--- a/pkg/lock-manager/storage/kubernetes/storage.go
+++ b/pkg/lock-manager/storage/kubernetes/storage.go
@@ -14,10 +14,8 @@ import (
 
 	coordv1 "k8s.io/api/coordination/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
 	v1 "k8s.io/client-go/kubernetes/typed/coordination/v1"
-	"k8s.io/client-go/tools/clientcmd"
 )
 
 const keyformat = "fleetlock-reservation-%s-"
@@ -28,17 +26,12 @@ type KubernetesBackend struct {
 }
 
 type KubernetesConfig struct {
-	Kubeconfig string `yaml:"kubeconfig,omitempty"`
+	Kubeconfig string `yaml:"-"`
 	Namespace  string `yaml:"namespace,omitempty"`
 }
 
 func NewKubernetesBackend(cfg KubernetesConfig) (*KubernetesBackend, error) {
-	config, err := clientcmd.BuildConfigFromFlags("", cfg.Kubeconfig)
-	if err != nil {
-		return nil, err
-	}
-
-	client, err := kubernetes.NewForConfig(config)
+	client, err := utils.CreateNewClientset(cfg.Kubeconfig)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/server/responses.go
+++ b/pkg/server/responses.go
@@ -37,4 +37,8 @@ var (
 		Kind:  "all_slots_full",
 		Value: "Could not reserve a slot as all slots in the group are currently locked already",
 	}
+	msgWaitingForNodeDrain = FleetLockResponse{
+		Kind:  "waiting_for_node_drain",
+		Value: "The Slot has been reserved, but the node is not yet drained",
+	}
 )

--- a/pkg/systemd-utils/utils.go
+++ b/pkg/systemd-utils/utils.go
@@ -1,0 +1,45 @@
+package systemdutils
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"strings"
+)
+
+// https://github.com/coreos/zincati/blob/main/src/identity/mod.rs
+const ZincatiAppID = "de35106b6ec24688b63afddaa156679b"
+
+// Derive the local app id for zincati from the machine id
+func ZincatiMachineID(machineID string) (string, error) {
+	return AppSpecificID(machineID, ZincatiAppID)
+}
+
+// Derive the machine specific app id from a given apps id and the local machine id
+func AppSpecificID(machineID, appID string) (string, error) {
+	// Remove any UUID dash formatting
+	machineID = strings.ReplaceAll(machineID, "-", "")
+
+	machineBytes, err := hex.DecodeString(machineID)
+	if err != nil {
+		return "", err
+	}
+	appBytes, err := hex.DecodeString(appID)
+	if err != nil {
+		return "", err
+	}
+
+	mac := hmac.New(sha256.New, machineBytes)
+	mac.Write(appBytes)
+	sum := mac.Sum(nil)
+
+	// UUID v4 settings
+	// https://docs.rs/libsystemd/0.3.1/src/libsystemd/id128.rs.html#52-54
+	// https://github.com/systemd/systemd/blob/5a7eb46c0206411d380543021291b4bca0b6f59f/src/libsystemd/sd-id128/id128-util.c#L199
+	sum[6] = (sum[6] & 0x0F) | 0x40
+	sum[8] = (sum[8] & 0x3F) | 0x80
+
+	id := string(sum)[:16]
+	return fmt.Sprintf("%x", id), nil
+}

--- a/pkg/systemd-utils/utils_test.go
+++ b/pkg/systemd-utils/utils_test.go
@@ -1,0 +1,47 @@
+package systemdutils
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestZincatiMachineID(t *testing.T) {
+	tMatrix := []struct {
+		MachineID string
+		Result    string
+	}{
+		{"dfd7882acda64c34aca76193c46f5d4e", "35ba2101ae3f4d45b96e9c51f461bbff"},
+		{"37974b3f7dc54f949209b4fd5b3c5704", "f59c4fa7d80e406f83993d64abf922e3"},
+		{"4473d601f9234ff2a84617c3eaeeea35", "7742030900754495bfeb49c7d1f4d653"},
+		{"10c30367c3cb44eaaab432e552061395", "72fe241381444dee85d824b8ec33a70f"},
+		{"b0236093845b4344930e60dff4d355b0", "3a711518ca8542cb9249bf4fd859a5e1"},
+		{"384afb4f366a4afbbe07c6fd0b9b222a", "473ca41a469040bfb5968791e929d581"},
+		{"6a1ed0358a1b4e8eb16d2872a91358ce", "e9aa1d2389a541ba87046c5a2445b48d"},
+	}
+
+	for i, tCase := range tMatrix {
+		t.Run(fmt.Sprintf("#%d", i), func(t *testing.T) {
+			assert := assert.New(t)
+
+			res, err := ZincatiMachineID(tCase.MachineID)
+
+			assert.Nil(err)
+			assert.Equal(tCase.Result, res)
+		})
+	}
+}
+
+func TestAppSpecificID(t *testing.T) {
+	assert := assert.New(t)
+
+	res1, err1 := AppSpecificID("Not a hex string", "123456")
+	assert.Empty(res1)
+	assert.NotNil(err1)
+
+	res2, err2 := AppSpecificID("123456", "Not a hex string")
+
+	assert.Empty(res2)
+	assert.NotNil(err2)
+}


### PR DESCRIPTION
When a client requests a slot, the server tries to match it to a node in a kubernetes cluster and drain the node before allowing the client to continue. Same thing before releasing a reservation, the server will try to uncordon the node.

Moves kubeconfig from kubernetes storage configuration to be a global setting instead.