### PR TITLE
k8s: Switch context to background

### DIFF
--- a/pkg/lock-manager/storage/kubernetes/storage.go
+++ b/pkg/lock-manager/storage/kubernetes/storage.go
@@ -94,7 +94,7 @@ func (k *KubernetesBackend) Reserve(group string, id string) error {
 			HolderIdentity: &id,
 		},
 	}
-	_, err = k.client.Leases(k.namespace).Create(context.TODO(), lease, metav1.CreateOptions{})
+	_, err = k.client.Leases(k.namespace).Create(context.Background(), lease, metav1.CreateOptions{})
 
 	return err
 }
@@ -115,7 +115,7 @@ func (k *KubernetesBackend) Release(group string, id string) error {
 
 	for _, lease := range leases {
 		if *lease.Spec.HolderIdentity == id {
-			return k.client.Leases(k.namespace).Delete(context.TODO(), lease.GetName(), metav1.DeleteOptions{})
+			return k.client.Leases(k.namespace).Delete(context.Background(), lease.GetName(), metav1.DeleteOptions{})
 		}
 	}
 
@@ -150,7 +150,7 @@ func (k *KubernetesBackend) Close() error {
 func (k *KubernetesBackend) getLeasesForGroup(group string) ([]coordv1.Lease, error) {
 	// Kubernetes names do not allow uppercase
 	group = strings.ToLower(group)
-	leases, err := k.client.Leases(k.namespace).List(context.TODO(), metav1.ListOptions{})
+	leases, err := k.client.Leases(k.namespace).List(context.Background(), metav1.ListOptions{})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/lock-manager/storage/kubernetes/storage_test.go
+++ b/pkg/lock-manager/storage/kubernetes/storage_test.go
@@ -19,7 +19,7 @@ func TestConflictingGroupNames(t *testing.T) {
 			Name: nsName,
 		},
 	}
-	_, _ = client.CoreV1().Namespaces().Create(context.TODO(), ns, metav1.CreateOptions{})
+	_, _ = client.CoreV1().Namespaces().Create(context.Background(), ns, metav1.CreateOptions{})
 
 	assert := assert.New(t)
 
@@ -46,14 +46,14 @@ func TestCompliantLeaseNames(t *testing.T) {
 			Name: nsName,
 		},
 	}
-	_, _ = client.CoreV1().Namespaces().Create(context.TODO(), ns, metav1.CreateOptions{})
+	_, _ = client.CoreV1().Namespaces().Create(context.Background(), ns, metav1.CreateOptions{})
 
 	assert := assert.New(t)
 
 	err := storage.Reserve("default", "User")
 	assert.Nil(err, "Should reserve slot")
 
-	leases, _ := client.CoordinationV1().Leases(nsName).List(context.TODO(), metav1.ListOptions{})
+	leases, _ := client.CoordinationV1().Leases(nsName).List(context.Background(), metav1.ListOptions{})
 
 	validationRegex := regexp.MustCompile("^[a-z0-9.-]+$")
 

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -330,12 +330,12 @@ func initTestCluster(client *fake.Clientset) {
 			NodeInfo: v1.NodeSystemInfo{MachineID: testNodeMachineID},
 		},
 	}
-	_, _ = client.CoreV1().Nodes().Create(context.TODO(), testNode, metav1.CreateOptions{})
+	_, _ = client.CoreV1().Nodes().Create(context.Background(), testNode, metav1.CreateOptions{})
 
 	testNS := &v1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: testNamespace,
 		},
 	}
-	_, _ = client.CoreV1().Namespaces().Create(context.TODO(), testNS, metav1.CreateOptions{})
+	_, _ = client.CoreV1().Namespaces().Create(context.Background(), testNS, metav1.CreateOptions{})
 }

--- a/tests/storage/kubernetes_test.go
+++ b/tests/storage/kubernetes_test.go
@@ -18,7 +18,7 @@ func TestKubernetesBackend(t *testing.T) {
 			Name: nsName,
 		},
 	}
-	_, _ = client.CoreV1().Namespaces().Create(context.TODO(), ns, metav1.CreateOptions{})
+	_, _ = client.CoreV1().Namespaces().Create(context.Background(), ns, metav1.CreateOptions{})
 
 	RunLockManagerTestsuiteWithStorage(t, storage)
 }


### PR DESCRIPTION
context.TODO is only a placeholder. The proper call should be context.Background().
Admittedly this is mostly cosmetic, it should not change the functionality.