### PR TITLE
tests/redis: Fix loadbalancer test not testing loadbalancer

### DIFF
--- a/tests/storage/redis_test.go
+++ b/tests/storage/redis_test.go
@@ -26,10 +26,11 @@ func TestRedisBackend(t *testing.T) {
 }
 
 func TestRedisLoadbalancerBackend(t *testing.T) {
-	mr := miniredis.RunT(t)
+	mr1 := miniredis.RunT(t)
+	mr2 := miniredis.RunT(t)
 
 	cfg := redis.RedisConfig{
-		Addrs: []string{mr.Addr()},
+		Addrs: []string{mr1.Addr(), mr2.Addr()},
 	}
 
 	storage, err := redis.NewRedisBackend(cfg)


### PR DESCRIPTION
When switching to valkey-go, the loadbalancer now needs 2 addresses minimum. Otherwise it will simply use the client directly.
Add a second mock-database to the test in order to fix the issue.

Fixes: #74