### PR TITLE
storage/valkey: Rename redis package to valkey

### DIFF
--- a/examples/example-config.yaml
+++ b/examples/example-config.yaml
@@ -25,9 +25,11 @@ storage:
   #   sqlite:     Persistent, does not really support High Availability
   #   postgres:   Use postgres database
   #   mysql:      Use mysql database
-  #   redis:      Use redis database
+  #   valkey:     Use valkey database (Any redis-api compatible database will do)
   #   etcd:       Use etcd database
   #   kubernetes: Use kubernetes leases
+  #
+  #   redis:      DEPRECATED, use valkey instead. This option will be removed in a future release in 2025
   #
   # Default: memory
   #
@@ -55,12 +57,11 @@ storage:
     database: ""
     # Additional options for connections. Will be appended with ?
     options: ""
-  redis:
-    # The address of the redis database
-    address: "localhost:1234"
-    # (Optional) List of addresses when connectiong should be loadbalanced between active-active replicas.
+  valkey:
+    # Address(es) of the databases
+    # When more than 1 is provided, they will be loadbalanced via failover.
     addresses:
-      - ""
+      - "localhost:1234"
     # (Optional) Username for authentication
     username: ""
     # (Optional) Password for authentication
@@ -75,7 +76,7 @@ storage:
       enabled: false
       # Master name
       master: ""
-      # Addresses for sentinel server
+      # Addresses for sentinel server(s)
       addresses:
         - ""
       # (Optional) Username for authentication with sentinel

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -7,8 +7,8 @@ import (
 
 	lockmanager "github.com/heathcliff26/fleetlock/pkg/lock-manager"
 	"github.com/heathcliff26/fleetlock/pkg/lock-manager/storage/kubernetes"
-	"github.com/heathcliff26/fleetlock/pkg/lock-manager/storage/redis"
 	"github.com/heathcliff26/fleetlock/pkg/lock-manager/storage/sql"
+	"github.com/heathcliff26/fleetlock/pkg/lock-manager/storage/valkey"
 	"github.com/heathcliff26/fleetlock/pkg/server"
 	"github.com/stretchr/testify/assert"
 )
@@ -198,17 +198,17 @@ func TestInvalidConfigs(t *testing.T) {
 
 func TestEnvSubstitution(t *testing.T) {
 	c := DefaultConfig()
-	c.Storage.Type = "redis"
-	c.Storage.Redis = redis.RedisConfig{
-		Addr:     "localhost:4321",
-		Username: "redis",
+	c.Storage.Type = "valkey"
+	c.Storage.Valkey = valkey.ValkeyConfig{
+		Addrs:    []string{"localhost:4321"},
+		Username: "valkey",
 		Password: "testpass",
 		DB:       5,
 	}
 	c.Defaults()
 
-	t.Setenv("FLEETLOCK_REDIS_USERNAME", "redis")
-	t.Setenv("FLEETLOCK_REDIS_PASSWORD", "testpass")
+	t.Setenv("FLEETLOCK_VALKEY_USERNAME", "valkey")
+	t.Setenv("FLEETLOCK_VALKEY_PASSWORD", "testpass")
 
 	cfg, err := LoadConfig("testdata/env-substitution.yaml", true)
 

--- a/pkg/config/testdata/env-substitution.yaml
+++ b/pkg/config/testdata/env-substitution.yaml
@@ -1,7 +1,8 @@
 storage:
-  type: redis
-  redis:
-    address: "localhost:4321"
-    username: "${FLEETLOCK_REDIS_USERNAME}"
-    password: "${FLEETLOCK_REDIS_PASSWORD}"
+  type: valkey
+  valkey:
+    addresses:
+      - "localhost:4321"
+    username: "${FLEETLOCK_VALKEY_USERNAME}"
+    password: "${FLEETLOCK_VALKEY_PASSWORD}"
     db: 5

--- a/pkg/lock-manager/config.go
+++ b/pkg/lock-manager/config.go
@@ -6,6 +6,7 @@ import (
 	"github.com/heathcliff26/fleetlock/pkg/lock-manager/storage/kubernetes"
 	"github.com/heathcliff26/fleetlock/pkg/lock-manager/storage/redis"
 	"github.com/heathcliff26/fleetlock/pkg/lock-manager/storage/sql"
+	"github.com/heathcliff26/fleetlock/pkg/lock-manager/storage/valkey"
 )
 
 type StorageConfig struct {
@@ -13,6 +14,7 @@ type StorageConfig struct {
 	SQLite     sql.SQLiteConfig            `yaml:"sqlite,omitempty"`
 	Postgres   sql.PostgresConfig          `yaml:"postgres,omitempty"`
 	MySQL      sql.MySQLConfig             `yaml:"mysql,omitempty"`
+	Valkey     valkey.ValkeyConfig         `yaml:"valkey,omitempty"`
 	Redis      redis.RedisConfig           `yaml:"redis,omitempty"`
 	Etcd       etcd.EtcdConfig             `yaml:"etcd,omitempty"`
 	Kubernetes kubernetes.KubernetesConfig `yaml:"kubernetes,omitempty"`

--- a/pkg/lock-manager/manager.go
+++ b/pkg/lock-manager/manager.go
@@ -10,6 +10,7 @@ import (
 	"github.com/heathcliff26/fleetlock/pkg/lock-manager/storage/memory"
 	"github.com/heathcliff26/fleetlock/pkg/lock-manager/storage/redis"
 	"github.com/heathcliff26/fleetlock/pkg/lock-manager/storage/sql"
+	"github.com/heathcliff26/fleetlock/pkg/lock-manager/storage/valkey"
 	"github.com/heathcliff26/fleetlock/pkg/lock-manager/types"
 )
 
@@ -63,6 +64,8 @@ func NewManager(groups Groups, storageCfg StorageConfig) (*LockManager, error) {
 		storage, err = sql.NewMySQLBackend(storageCfg.MySQL)
 	case "redis":
 		storage, err = redis.NewRedisBackend(storageCfg.Redis)
+	case "valkey":
+		storage, err = valkey.NewValkeyBackend(storageCfg.Valkey)
 	case "etcd":
 		storage, err = etcd.NewEtcdBackend(storageCfg.Etcd)
 	case "kubernetes":

--- a/pkg/lock-manager/manager_test.go
+++ b/pkg/lock-manager/manager_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/heathcliff26/fleetlock/pkg/lock-manager/storage/kubernetes"
 	"github.com/heathcliff26/fleetlock/pkg/lock-manager/storage/redis"
 	"github.com/heathcliff26/fleetlock/pkg/lock-manager/storage/sql"
+	"github.com/heathcliff26/fleetlock/pkg/lock-manager/storage/valkey"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -102,6 +103,30 @@ func TestNewManager(t *testing.T) {
 				Type: "redis",
 				Redis: redis.RedisConfig{
 					Addr: "",
+				},
+			},
+			Error: "no alive address in InitAddress",
+		},
+		{
+			Name: "ValkeyBackend",
+			Storage: StorageConfig{
+				Type: "valkey",
+				Valkey: valkey.ValkeyConfig{
+					Addrs: []string{mr.Addr()},
+				},
+			},
+			Result: result{
+				groups:  initGroups(NewDefaultGroups()),
+				storage: "*valkey.ValkeyBackend",
+			},
+			Error: "",
+		},
+		{
+			Name: "ErrorNewValkeyBackend",
+			Storage: StorageConfig{
+				Type: "valkey",
+				Valkey: valkey.ValkeyConfig{
+					Addrs: []string{},
 				},
 			},
 			Error: "no alive address in InitAddress",

--- a/pkg/lock-manager/storage/valkey/loadbalancer.go
+++ b/pkg/lock-manager/storage/valkey/loadbalancer.go
@@ -1,0 +1,122 @@
+package valkey
+
+import (
+	"context"
+	"crypto/tls"
+	"log/slog"
+	"net"
+	"slices"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/valkey-io/valkey-go"
+)
+
+const loadbalancerHealtchCheckPeriod = time.Second * 10
+
+type loadbalancer struct {
+	// List of addresses for valkey endpoints
+	addrs []string
+	// Options for connecting to valkey
+	options valkey.ClientOption
+	// Context to cancle health check
+	ctx    context.Context
+	cancel context.CancelFunc
+
+	client   valkey.Client
+	selected int
+	rwlock   sync.RWMutex
+}
+
+// Create a new valkey client with loadbalanced connections
+func NewValkeyLoadbalancer(opt valkey.ClientOption) (valkey.Client, *loadbalancer, error) {
+	opt.ForceSingleClient = true
+
+	ctx, cancel := context.WithCancel(context.Background())
+	lb := &loadbalancer{
+		addrs:   opt.InitAddress,
+		options: opt,
+		ctx:     ctx,
+		cancel:  cancel,
+	}
+
+	opt.DialFn = lb.DialFn
+
+	client, err := valkey.NewClient(opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	lb.client = client
+	lb.PeriodicHealthCheck()
+
+	return client, lb, nil
+}
+
+// Determine the first healthy master node
+func (lb *loadbalancer) HealthCheck() {
+	for i, addr := range lb.addrs {
+		opt := lb.options
+		opt.InitAddress = []string{addr}
+
+		client, err := valkey.NewClient(opt)
+		if err != nil {
+			slog.Debug("Endpoint down", slog.String("addr", addr), "err", err)
+			continue
+		}
+		defer client.Close()
+
+		cmdInfo := client.B().Info().Build()
+		res, err := client.Do(context.Background(), cmdInfo).ToString()
+		if err != nil {
+			slog.Error("Failed to get endpoint info", slog.String("addr", addr), "err", err)
+			continue
+		}
+		s := strings.Split(res, "\r\n")
+		if slices.Contains(s, "role:master") || slices.Contains(s, "role:active-replica") {
+			lb.rwlock.Lock()
+			defer lb.rwlock.Unlock()
+
+			if lb.selected != i {
+				lb.selected = i
+				slog.Info("Failed over to new database", slog.String("addr", addr))
+				// valkey keeps a connection. Try to ping it to ensure it gets terminated and the next try will be a new connection
+				_ = lb.client.Do(context.Background(), client.B().Ping().Build())
+			}
+			break
+		}
+	}
+}
+
+// Starts go-routine that periodically runs a healthcheck in the background
+func (lb *loadbalancer) PeriodicHealthCheck() {
+	go lb.periodicHealthCheck()
+}
+
+func (lb *loadbalancer) periodicHealthCheck() {
+	for {
+		lb.HealthCheck()
+
+		select {
+		case <-lb.ctx.Done():
+			return
+		case <-time.After(loadbalancerHealtchCheckPeriod):
+		}
+	}
+}
+
+func (lb *loadbalancer) DialFn(_ string, dialer *net.Dialer, cfg *tls.Config) (conn net.Conn, err error) {
+	lb.rwlock.RLock()
+	defer lb.rwlock.RUnlock()
+	dst := lb.addrs[lb.selected]
+
+	if cfg != nil {
+		return tls.DialWithDialer(dialer, "tcp", dst, cfg)
+	}
+	return dialer.Dial("tcp", dst)
+}
+
+func (lb *loadbalancer) Close() {
+	lb.cancel()
+}

--- a/pkg/lock-manager/storage/valkey/loadbalancer_test.go
+++ b/pkg/lock-manager/storage/valkey/loadbalancer_test.go
@@ -1,0 +1,140 @@
+package valkey
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/heathcliff26/fleetlock/tests/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/valkey-io/valkey-go"
+)
+
+func TestLoadbalancer(t *testing.T) {
+	t.Run("Basic", func(t *testing.T) {
+		mr1 := miniredis.RunT(t)
+		mr2 := miniredis.RunT(t)
+
+		opt := valkey.ClientOption{
+			InitAddress:  []string{mr1.Addr(), mr2.Addr()},
+			DisableCache: true,
+		}
+
+		assert := assert.New(t)
+
+		client, lb, err := NewValkeyLoadbalancer(opt)
+		if !assert.NoError(err, "Should not return an error") || !assert.NotNil(client, "Should return a client") || !assert.NotNil(lb, "Should return a loadbalancer") {
+			t.FailNow()
+		}
+		t.Cleanup(func() {
+			lb.Close()
+			client.Close()
+		})
+
+		res, err := client.Do(context.Background(), client.B().Ping().Build()).ToString()
+
+		assert.Nil(err, "Can reach client")
+		assert.Equal("PONG", res, "Can reach client")
+	})
+	t.Run("Failover", func(t *testing.T) {
+		if !utils.HasContainerRuntimer() {
+			t.Skip("Missing Container Runtime")
+		}
+
+		err := utils.ExecCRI("run", "--name", "fleetlock-valkey-loadbalancer-failover-1", "-d", "--net", "host", "docker.io/eqalpha/keydb:latest", "--port", "6379", "--active-replica", "yes", "--replicaof", "localhost", "6380")
+		if err != nil {
+			t.Fatalf("Failed to start test db: %v\n", err)
+		}
+		t.Cleanup(func() {
+			_ = utils.ExecCRI("stop", "fleetlock-valkey-loadbalancer-failover-1")
+			_ = utils.ExecCRI("rm", "fleetlock-valkey-loadbalancer-failover-1")
+		})
+		err = utils.ExecCRI("run", "--name", "fleetlock-valkey-loadbalancer-failover-2", "-d", "--net", "host", "docker.io/eqalpha/keydb:latest", "--port", "6380", "--active-replica", "yes", "--replicaof", "localhost", "6379")
+		if err != nil {
+			t.Fatalf("Failed to start test db: %v\n", err)
+		}
+		t.Cleanup(func() {
+			_ = utils.ExecCRI("stop", "fleetlock-valkey-loadbalancer-failover-2")
+			_ = utils.ExecCRI("rm", "fleetlock-valkey-loadbalancer-failover-2")
+		})
+
+		assert := assert.New(t)
+
+		opt := valkey.ClientOption{
+			InitAddress:  []string{"localhost:6379", "localhost:6380"},
+			DisableCache: true,
+		}
+		client, lb, err := NewValkeyLoadbalancer(opt)
+		if !assert.NoError(err, "Should not return an error") || !assert.NotNil(client, "Should return a client") || !assert.NotNil(lb, "Should return a loadbalancer") {
+			t.FailNow()
+		}
+		t.Cleanup(func() {
+			lb.Close()
+			client.Close()
+		})
+
+		assert.Equal(0, lb.selected, "Should have currently the first client selected")
+
+		err = utils.ExecCRI("stop", "fleetlock-valkey-loadbalancer-failover-1")
+		if err != nil {
+			t.Fatalf("Failed to stop keydb instance: %v\n", err)
+		}
+
+		lb.HealthCheck()
+		if !assert.Equal(1, lb.selected, "Should have failed over") {
+			t.FailNow()
+		}
+
+		res, err := client.Do(context.Background(), client.B().Ping().Build()).ToString()
+
+		assert.NoError(err, "Should have failed over")
+		assert.Equal("PONG", res, "Should have failed over")
+	})
+	t.Run("DeadlockCheck", func(t *testing.T) {
+		mr1 := miniredis.RunT(t)
+		mr2 := miniredis.RunT(t)
+
+		opt := valkey.ClientOption{
+			InitAddress:  []string{mr1.Addr(), mr2.Addr()},
+			DisableCache: true,
+		}
+
+		assert := assert.New(t)
+
+		client, lb, err := NewValkeyLoadbalancer(opt)
+		if !assert.NoError(err, "Should not return an error") || !assert.NotNil(client, "Should return a client") || !assert.NotNil(lb, "Should return a loadbalancer") {
+			t.FailNow()
+		}
+		t.Cleanup(func() {
+			lb.Close()
+			client.Close()
+		})
+
+		// Ensure no failover happens automatically
+		lb.cancel()
+
+		assert.Equal(0, lb.selected, "Should have currently the first client selected")
+
+		mr1.Close()
+
+		done := make(chan struct{}, 1)
+
+		go func() {
+			lb.HealthCheck()
+			done <- struct{}{}
+			close(done)
+		}()
+		go func() {
+			_, err = client.Do(context.Background(), client.B().Ping().Build()).ToString()
+
+			assert.Error(err, "Call should fail")
+		}()
+
+		select {
+		case <-done:
+		case <-time.After(10 * time.Second):
+			t.Fatal("Timed out waiting for the failover to finished")
+		}
+	})
+}

--- a/pkg/lock-manager/storage/valkey/storage.go
+++ b/pkg/lock-manager/storage/valkey/storage.go
@@ -1,0 +1,162 @@
+package valkey
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"time"
+
+	"github.com/heathcliff26/fleetlock/pkg/lock-manager/types"
+	"github.com/valkey-io/valkey-go"
+)
+
+const keyformat = "group:%s,id:%s"
+
+type ValkeyBackend struct {
+	client valkey.Client
+	lb     *loadbalancer
+}
+
+type ValkeyConfig struct {
+	Addrs    []string             `yaml:"addresses,omitempty"`
+	Username string               `yaml:"username,omitempty"`
+	Password string               `yaml:"password,omitempty"`
+	DB       int                  `yaml:"db,omitempty"`
+	TLS      bool                 `yaml:"tls,omitempty"`
+	Sentinel ValkeySentinelConfig `yaml:"sentinel,omitempty"`
+}
+
+type ValkeySentinelConfig struct {
+	Enabled    bool     `yaml:"enabled,omitempty"`
+	MasterName string   `yaml:"master,omitempty"`
+	Addresses  []string `yaml:"addresses,omitempty"`
+	Username   string   `yaml:"username,omitempty"`
+	Password   string   `yaml:"password,omitempty"`
+}
+
+func NewValkeyBackend(cfg ValkeyConfig) (*ValkeyBackend, error) {
+	var client valkey.Client
+	var lb *loadbalancer
+	var tlsConfig *tls.Config
+
+	if cfg.TLS {
+		tlsConfig = &tls.Config{}
+	}
+
+	opt := valkey.ClientOption{
+		InitAddress: cfg.Addrs,
+		Username:    cfg.Username,
+		Password:    cfg.Password,
+		SelectDB:    cfg.DB,
+		TLSConfig:   tlsConfig,
+
+		DisableCache: true,
+	}
+
+	var err error
+	switch {
+	case cfg.Sentinel.Enabled:
+		opt.Sentinel = valkey.SentinelOption{
+			MasterSet: cfg.Sentinel.MasterName,
+			Username:  cfg.Sentinel.Username,
+			Password:  cfg.Sentinel.Password,
+		}
+		opt.InitAddress = cfg.Sentinel.Addresses
+
+		client, err = valkey.NewClient(opt)
+	case len(cfg.Addrs) > 1:
+		client, lb, err = NewValkeyLoadbalancer(opt)
+	default:
+		client, err = valkey.NewClient(opt)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to connect to valkey server: %v", err)
+	}
+
+	return &ValkeyBackend{
+		client: client,
+		lb:     lb,
+	}, nil
+}
+
+// Reserve a lock for the given group.
+// Returns true if the lock is successfully reserved, even if the lock is already held by the specific id
+func (r *ValkeyBackend) Reserve(group string, id string) error {
+	key := fmt.Sprintf(keyformat, group, id)
+	ctx := context.Background()
+
+	cmdSetNX := r.client.B().Setnx().Key(key).Value(time.Now().String()).Build()
+	cmdSAdd := r.client.B().Sadd().Key(group).Member(key).Build()
+
+	ok, err := r.client.Do(ctx, cmdSetNX).AsBool()
+	if err != nil {
+		return fmt.Errorf("failed to create key: %w", err)
+	}
+
+	if ok {
+		err := r.client.Do(ctx, cmdSAdd).Error()
+		if err != nil {
+			return fmt.Errorf("failed to add key to group list: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// Returns the current number of locks for the given group
+func (r *ValkeyBackend) GetLocks(group string) (int, error) {
+	cmdSCard := r.client.B().Scard().Key(group).Build()
+	result, err := r.client.Do(context.Background(), cmdSCard).AsInt64()
+	if err != nil {
+		return 0, fmt.Errorf("failed to get locks from database: %w", err)
+	}
+	return int(result), nil
+}
+
+// Release the lock currently held by the id.
+// Does not fail when no lock is held.
+func (r *ValkeyBackend) Release(group string, id string) error {
+	key := fmt.Sprintf(keyformat, group, id)
+	ctx := context.Background()
+
+	cmdDel := r.client.B().Del().Key(key).Build()
+	cmdSRem := r.client.B().Srem().Key(group).Member(key).Build()
+
+	err := r.client.Do(ctx, cmdDel).Error()
+	if err != nil {
+		return fmt.Errorf("failed to delete key in database: %w", err)
+	}
+
+	err = r.client.Do(ctx, cmdSRem).Error()
+	if err != nil {
+		return fmt.Errorf("failed to remove key from group: %w", err)
+	}
+	return nil
+}
+
+// Return all locks older than x
+func (r *ValkeyBackend) GetStaleLocks(ts time.Duration) ([]types.Lock, error) {
+	panic("not implemented") // TODO: Implement
+}
+
+// Check if a given id already has a lock for this group
+func (r *ValkeyBackend) HasLock(group string, id string) (bool, error) {
+	key := fmt.Sprintf(keyformat, group, id)
+	ctx := context.Background()
+
+	cmdExists := r.client.B().Exists().Key(key).Build()
+	count, err := r.client.Do(ctx, cmdExists).AsInt64()
+	if err != nil {
+		return false, fmt.Errorf("failed to count keys in group: %w", err)
+	}
+	return count == 1, nil
+}
+
+// Calls all necessary finalization if necessary
+func (r *ValkeyBackend) Close() error {
+	if r.lb != nil {
+		r.lb.Close()
+	}
+	r.client.Close()
+	return nil
+}

--- a/tests/storage/testdata/redis-sentinel.conf
+++ b/tests/storage/testdata/redis-sentinel.conf
@@ -1,3 +1,0 @@
-sentinel monitor redis-sentinel-backend 127.0.0.1 6379 1
-
-sentinel announce-port 26379

--- a/tests/storage/testdata/valkey-sentinel.conf
+++ b/tests/storage/testdata/valkey-sentinel.conf
@@ -1,0 +1,3 @@
+sentinel monitor valkey-sentinel-backend 127.0.0.1 6379 1
+
+sentinel announce-port 26379


### PR DESCRIPTION
Rename the redis package, including all references and functions to valkey.
Drop the addr config option in the new valkey package.
Keep the redis package for now, to ensure backward compatibility until it will be removed later in 2025.

Fixes: #70
Fixes: #72