### PR TITLE
server: Create a client package for imports

### DIFF
--- a/pkg/server/client/types.go
+++ b/pkg/server/client/types.go
@@ -1,0 +1,15 @@
+package client
+
+type FleetLockRequest struct {
+	Client FleetLockRequestClient `json:"client_params"`
+}
+
+type FleetLockRequestClient struct {
+	ID    string `json:"id"`
+	Group string `json:"group"`
+}
+
+type FleetLockResponse struct {
+	Kind  string `json:"kind"`
+	Value string `json:"value"`
+}

--- a/pkg/server/client/utils.go
+++ b/pkg/server/client/utils.go
@@ -1,0 +1,42 @@
+package client
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+)
+
+// Parse an http request	 body and extract the parameters
+func ParseRequest(body io.ReadCloser) (FleetLockRequest, error) {
+	var res FleetLockRequest
+	err := json.NewDecoder(body).Decode(&res)
+	if err != nil {
+		return FleetLockRequest{}, err
+	}
+	return res, nil
+}
+
+// Parse an http response body and extract the parameters
+func ParseResponse(body io.ReadCloser) (FleetLockResponse, error) {
+	var res FleetLockResponse
+	err := json.NewDecoder(body).Decode(&res)
+	if err != nil {
+		return FleetLockResponse{}, err
+	}
+	return res, nil
+}
+
+// Create a new http request pody based on the provided parameters
+func PrepareRequest(group, id string) (io.Reader, error) {
+	req := FleetLockRequest{
+		Client: FleetLockRequestClient{
+			ID:    id,
+			Group: group,
+		},
+	}
+	body, err := json.Marshal(req)
+	if err != nil {
+		return nil, err
+	}
+	return bytes.NewReader(body), nil
+}

--- a/pkg/server/responses.go
+++ b/pkg/server/responses.go
@@ -1,43 +1,45 @@
 package server
 
+import "github.com/heathcliff26/fleetlock/pkg/server/client"
+
 var (
-	msgNotFound = FleetLockResponse{
+	msgNotFound = client.FleetLockResponse{
 		Kind:  "not_found",
 		Value: "The requested url is not found on this server",
 	}
-	msgWrongMethod = FleetLockResponse{
+	msgWrongMethod = client.FleetLockResponse{
 		Kind:  "bad_request",
 		Value: "Only accepts POST request",
 	}
-	msgMissingFleetLockHeader = FleetLockResponse{
+	msgMissingFleetLockHeader = client.FleetLockResponse{
 		Kind:  "missing_fleetlock_header",
 		Value: "The header fleet-lock-protocol must be set to true",
 	}
-	msgRequestParseFailed = FleetLockResponse{
+	msgRequestParseFailed = client.FleetLockResponse{
 		Kind:  "bad_request",
 		Value: "The request json could not be parsed",
 	}
-	msgInvalidGroupValue = FleetLockResponse{
+	msgInvalidGroupValue = client.FleetLockResponse{
 		Kind:  "bad_request",
 		Value: "The value of group is invalid or empty. It must conform to \"" + groupValidationPattern + "\"",
 	}
-	msgEmptyID = FleetLockResponse{
+	msgEmptyID = client.FleetLockResponse{
 		Kind:  "bad_request",
 		Value: "The value of id is empty",
 	}
-	msgUnexpectedError = FleetLockResponse{
+	msgUnexpectedError = client.FleetLockResponse{
 		Kind:  "error",
 		Value: "An unexpected error occured",
 	}
-	msgSuccess = FleetLockResponse{
+	msgSuccess = client.FleetLockResponse{
 		Kind:  "success",
 		Value: "The operation was succesfull",
 	}
-	msgSlotsFull = FleetLockResponse{
+	msgSlotsFull = client.FleetLockResponse{
 		Kind:  "all_slots_full",
 		Value: "Could not reserve a slot as all slots in the group are currently locked already",
 	}
-	msgWaitingForNodeDrain = FleetLockResponse{
+	msgWaitingForNodeDrain = client.FleetLockResponse{
 		Kind:  "waiting_for_node_drain",
 		Value: "The Slot has been reserved, but the node is not yet drained",
 	}

--- a/pkg/server/utils.go
+++ b/pkg/server/utils.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"log/slog"
 	"net/http"
+
+	"github.com/heathcliff26/fleetlock/pkg/server/client"
 )
 
 func ReadUserIP(req *http.Request) string {
@@ -18,7 +20,7 @@ func ReadUserIP(req *http.Request) string {
 }
 
 // Send a response to the writer and handle impossible parse errors
-func sendResponse(rw http.ResponseWriter, res FleetLockResponse) {
+func sendResponse(rw http.ResponseWriter, res client.FleetLockResponse) {
 	b, err := json.Marshal(res)
 	if err != nil {
 		slog.Error("Failed to create Response", "err", err)


### PR DESCRIPTION
Create a client package to help clients create fleetlock requests. The package should not depend on anything, to ensure that the import remains small, as the server package imports are huge.