### PR TITLE
server: Add /healthz check endpoint

### DIFF
--- a/examples/example-deployment.yaml
+++ b/examples/example-deployment.yaml
@@ -113,17 +113,19 @@ spec:
               containerPort: 8080
               protocol: TCP
           livenessProbe:
-            tcpSocket:
+            httpGet:
+              path: "/healthz"
               port: http
             initialDelaySeconds: 5
-            periodSeconds: 10
+            periodSeconds: 5
             successThreshold: 1
             failureThreshold: 3
           readinessProbe:
-            tcpSocket:
+            httpGet:
+              path: "/healthz"
               port: http
             initialDelaySeconds: 5
-            periodSeconds: 10
+            periodSeconds: 5
           volumeMounts:
             - mountPath: /config
               name: fleetlock-config

--- a/pkg/server/client/types.go
+++ b/pkg/server/client/types.go
@@ -13,3 +13,8 @@ type FleetLockResponse struct {
 	Kind  string `json:"kind"`
 	Value string `json:"value"`
 }
+
+type FleetlockHealthResponse struct {
+	Status string `json:"status"`
+	Error  string `json:"error"`
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -211,9 +211,20 @@ func (s *Server) matchNodeToId(rw http.ResponseWriter, params client.FleetLockRe
 	return node, true
 }
 
+// Return a health status of the server
+// URL: /healthz
+func (s *Server) handleHealthCheck(rw http.ResponseWriter, _ *http.Request) {
+	rw.Header().Set("Content-Type", "application/json")
+	status := client.FleetlockHealthResponse{
+		Status: "ok",
+	}
+	sendResponse(rw, status)
+}
+
 // Starts the server and exits with error if that fails
 func (s *Server) Run() error {
 	http.HandleFunc("/", s.requestHandler)
+	http.HandleFunc("/healthz", s.handleHealthCheck)
 
 	slog.Info("Starting server", slog.String("listen", s.cfg.Listen), slog.Bool("ssl", s.cfg.SSL.Enabled))
 

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"encoding/json"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -283,6 +284,27 @@ func TestUncordonNode(t *testing.T) {
 	rr = httptest.NewRecorder()
 	params.Client.ID = testNodeZincatiID
 	assert.True(s.uncordonNode(rr, params))
+}
+
+func TestHealthCheck(t *testing.T) {
+	s := &Server{}
+	rr := httptest.NewRecorder()
+
+	assert := assert.New(t)
+
+	s.handleHealthCheck(rr, nil)
+
+	assert.Equal(http.StatusOK, rr.Result().StatusCode, "Health Check should return with 200")
+	assert.Equal("application/json", rr.Header().Get("Content-Type"), "Content type should be json")
+
+	var res client.FleetlockHealthResponse
+	err := json.NewDecoder(rr.Result().Body).Decode(&res)
+
+	assert.NoError(err, "Response should be parsable")
+	expectedRes := client.FleetlockHealthResponse{
+		Status: "ok",
+	}
+	assert.Equal(expectedRes, res, "Response should match")
 }
 
 func newFleetlockRequest(group, id string) client.FleetLockRequest {

--- a/pkg/server/utils.go
+++ b/pkg/server/utils.go
@@ -4,8 +4,6 @@ import (
 	"encoding/json"
 	"log/slog"
 	"net/http"
-
-	"github.com/heathcliff26/fleetlock/pkg/server/client"
 )
 
 func ReadUserIP(req *http.Request) string {
@@ -20,7 +18,7 @@ func ReadUserIP(req *http.Request) string {
 }
 
 // Send a response to the writer and handle impossible parse errors
-func sendResponse(rw http.ResponseWriter, res client.FleetLockResponse) {
+func sendResponse(rw http.ResponseWriter, res any) {
 	b, err := json.Marshal(res)
 	if err != nil {
 		slog.Error("Failed to create Response", "err", err)


### PR DESCRIPTION
Add a generic health checkpoint for testing the status of the server. Currently it only tests if the http server is running.