### PR TITLE
go.mod: Bump go version to 1.23

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/heathcliff26/fleetlock
 
-go 1.22.0
-
-toolchain go1.23.1
+go 1.23
 
 require (
 	github.com/alicebob/miniredis/v2 v2.33.0


### PR DESCRIPTION
Update go version to latest supported version to get rid of the toolchain directive in the file.