### PR TITLE
config: Add option to configure max retries for node drain

### DIFF
--- a/examples/example-config.yaml
+++ b/examples/example-config.yaml
@@ -9,6 +9,9 @@ kubernetes:
   # The timeout for drain node in seconds.
   # Defaults to 5m.
   drainTimeoutSeconds: 300
+  # The amount of times draining the node will be retried before giving up.
+  # Default value of 0 means infinite retries.
+  drainRetries: 0
 
 server:
   # The listen address of the server in the form of <ip>:<port>

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -64,6 +64,7 @@ func TestValidConfigs(t *testing.T) {
 	}
 	cfgKubernetes.KubernetesConfig.Kubeconfig = "some-path"
 	cfgKubernetes.KubernetesConfig.DrainTimeoutSeconds = 60
+	cfgKubernetes.KubernetesConfig.DrainRetries = 3
 
 	tMatrix := []struct {
 		Name, Path string

--- a/pkg/config/testdata/valid-config-kubernetes.yaml
+++ b/pkg/config/testdata/valid-config-kubernetes.yaml
@@ -6,3 +6,4 @@ storage:
 kubernetes:
   kubeconfig: "some-path"
   drainTimeoutSeconds: 60
+  drainRetries: 3

--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -73,6 +73,10 @@ func (c *Client) DrainNode(node string) error {
 
 	err = c.drainNode(ctx, node)
 	if err != nil {
+		err2 := lease.Error(ctx)
+		if err2 != nil {
+			slog.Error("Failed to set drain lease to error state", slog.String("node", node), "err", err)
+		}
 		return err
 	}
 

--- a/pkg/k8s/config.go
+++ b/pkg/k8s/config.go
@@ -3,6 +3,7 @@ package k8s
 type Config struct {
 	Kubeconfig          string `yaml:"kubeconfig,omitempty"`
 	DrainTimeoutSeconds int32  `yaml:"drainTimeoutSeconds,omitempty"`
+	DrainRetries        int    `yaml:"drainRetries,omitempty"`
 }
 
 func NewDefaultConfig() Config {

--- a/pkg/k8s/errors.go
+++ b/pkg/k8s/errors.go
@@ -27,7 +27,7 @@ func NewErrorInvalidLease() error {
 }
 
 func (e ErrorInvalidLease) Error() string {
-	return "Invalid lease, either AcquireTime or LeaseDurationSeconds are nil"
+	return "Invalid lease, either AcquireTime, LeaseDurationSeconds or HolderIdentity are nil"
 }
 
 type ErrorDrainTimeoutSecondsInvalid struct{}

--- a/pkg/k8s/errors.go
+++ b/pkg/k8s/errors.go
@@ -30,16 +30,6 @@ func (e ErrorInvalidLease) Error() string {
 	return "Invalid lease, either AcquireTime or LeaseDurationSeconds are nil"
 }
 
-type ErrorLeaseNil struct{}
-
-func NewErrorLeaseNil() error {
-	return ErrorLeaseNil{}
-}
-
-func (e ErrorLeaseNil) Error() string {
-	return "Tried changing lease, but lease status on cluster is unknown"
-}
-
 type ErrorDrainTimeoutSecondsInvalid struct{}
 
 func NewErrorDrainTimeoutSecondsInvalid() error {

--- a/pkg/k8s/lease.go
+++ b/pkg/k8s/lease.go
@@ -79,8 +79,7 @@ func (l *lease) update(ctx context.Context) error {
 	return nil
 }
 
-// Return the count of failed attempts
-func (l *lease) GetFailCounter(ctx context.Context) (int, error) {
+func (l *lease) getFailCounter(ctx context.Context) (int, error) {
 	if l.lease == nil {
 		err := l.get(ctx)
 		if err != nil {
@@ -95,10 +94,19 @@ func (l *lease) GetFailCounter(ctx context.Context) (int, error) {
 	return strconv.Atoi(failCounterStr)
 }
 
+// Return the count of failed attempts, defaults to 0 if no lease is found
+func (l *lease) GetFailCounter(ctx context.Context) (int, error) {
+	count, err := l.getFailCounter(ctx)
+	if errors.IsNotFound(err) {
+		return 0, nil
+	}
+	return count, err
+}
+
 // Increase the fail counter by 1.
 // Does not call update!!!
 func (l *lease) increaseFailCounter(ctx context.Context) error {
-	failCount, err := l.GetFailCounter(ctx)
+	failCount, err := l.getFailCounter(ctx)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Add a configuration option for maximum number of retries before a reservation
or lock for the node is granted anyway.

Add fail counter to lease.

Use internal functions for updating/fetching/creating the lease in the cluster.
Add comments to the functions.
