### PR TITLE
tests: Fix selinux permissions when running tests

### DIFF
--- a/tests/storage/valkey_test.go
+++ b/tests/storage/valkey_test.go
@@ -59,7 +59,7 @@ func TestValkeySentinelBackend(t *testing.T) {
 	})
 
 	err = utils.ExecCRI("run", "--name", "fleetlock-valkey-sentinel-sentinel", "-d", "--net", "host",
-		"-v", "./testdata/valkey-sentinel.conf:/config/sentinel.conf", "--userns=keep-id",
+		"-v", "./testdata/valkey-sentinel.conf:/config/sentinel.conf:z", "--userns=keep-id",
 		"docker.io/valkey/valkey:latest",
 		"/config/sentinel.conf", "--sentinel",
 	)


### PR DESCRIPTION
When running the valkey tests, mounting the configuration file inside the container fails because of selinux.
Add the `:z` option to mount it with correct permissions inside the container.