### PR TITLE
Makefile: Add fmt and validate commands 

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,6 +39,12 @@ jobs:
   unit-tests:
     uses: heathcliff26/ci/.github/workflows/golang-unit-tests.yaml@main
 
+  validate:
+    uses: heathcliff26/ci/.github/workflows/golang-build.yaml@main
+    with:
+      cache: false
+      cmd: "make validate"
+
   build:
     uses: heathcliff26/ci/.github/workflows/build-container.yaml@main
     needs:

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ update-deps:
 coverprofile:
 	hack/coverprofile.sh
 
-lint:
+lint: golangci-lint
 	golangci-lint run -v
 
 fmt:
@@ -29,6 +29,9 @@ fmt:
 
 validate:
 	hack/validate.sh
+
+golangci-lint:
+	go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
 
 .PHONY: \
 	default \

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,12 @@ coverprofile:
 lint:
 	golangci-lint run -v
 
+fmt:
+	gofmt -s -w ./cmd ./pkg ./tests
+
+validate:
+	hack/validate.sh
+
 .PHONY: \
 	default \
 	build \
@@ -32,4 +38,6 @@ lint:
 	update-deps \
 	coverprofile \
 	lint \
+	fmt \
+	validate \
 	$(NULL)

--- a/hack/validate.sh
+++ b/hack/validate.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -e
+
+script_dir="$(dirname "${BASH_SOURCE[0]}" | xargs realpath)"
+
+echo "Check if source code is formatted"
+make fmt
+rc=0
+git update-index --refresh && git diff-index --quiet HEAD -- || rc=1
+if [ $rc -ne 0 ]; then
+    echo "FATAL: Need to run \"make fmt\""
+    exit 1
+fi


### PR DESCRIPTION
Add a command to format the go code.
Add a command to validate that the workspace is clean.
Improve lint by installing golangci-lint if not available.
Add validate step to ci jobs to ensure code is always properly formatted.