### PR TITLE
fake: Add new fake server for testing

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1,4 +1,4 @@
-package client
+package api
 
 type FleetLockRequest struct {
 	Client FleetLockRequestClient `json:"client_params"`
@@ -14,6 +14,7 @@ type FleetLockResponse struct {
 	Value string `json:"value"`
 }
 
+// Not part of the actual api specification
 type FleetlockHealthResponse struct {
 	Status string `json:"status"`
 	Error  string `json:"error"`

--- a/pkg/api/utils.go
+++ b/pkg/api/utils.go
@@ -1,0 +1,42 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+)
+
+// Parse an http request	 body and extract the parameters
+func ParseRequest(body io.ReadCloser) (FleetLockRequest, error) {
+	var res FleetLockRequest
+	err := json.NewDecoder(body).Decode(&res)
+	if err != nil {
+		return FleetLockRequest{}, err
+	}
+	return res, nil
+}
+
+// Parse an http response body and extract the parameters
+func ParseResponse(body io.ReadCloser) (FleetLockResponse, error) {
+	var res FleetLockResponse
+	err := json.NewDecoder(body).Decode(&res)
+	if err != nil {
+		return FleetLockResponse{}, err
+	}
+	return res, nil
+}
+
+// Create a new http request pody based on the provided parameters
+func PrepareRequest(group, id string) (io.Reader, error) {
+	req := FleetLockRequest{
+		Client: FleetLockRequestClient{
+			ID:    id,
+			Group: group,
+		},
+	}
+	body, err := json.Marshal(req)
+	if err != nil {
+		return nil, err
+	}
+	return bytes.NewReader(body), nil
+}

--- a/pkg/fake/server.go
+++ b/pkg/fake/server.go
@@ -1,0 +1,80 @@
+package fake
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/heathcliff26/fleetlock/pkg/api"
+	"github.com/stretchr/testify/assert"
+)
+
+type FakeServer struct {
+	server *httptest.Server
+	assert *assert.Assertions
+
+	Path       string
+	StatusCode int
+	Group      string
+	ID         string
+}
+
+func NewFakeServer(t *testing.T, statusCode int, path string) *FakeServer {
+	s := &FakeServer{
+		assert:     assert.New(t),
+		Path:       path,
+		StatusCode: statusCode,
+	}
+
+	s.server = httptest.NewServer(http.HandlerFunc(s.handleRequest))
+
+	return s
+}
+
+func (s *FakeServer) handleRequest(rw http.ResponseWriter, req *http.Request) {
+	s.assert.Contains([]string{"/v1/pre-reboot", "/v1/steady-state"}, req.URL.String(), "Should request a valid url")
+	if s.Path != "" {
+		s.assert.Equal(s.Path, req.URL.String(), "Should use the specified URL")
+	}
+
+	s.assert.Equal(http.MethodPost, req.Method, "Should be POST request")
+	s.assert.Equal("true", strings.ToLower(req.Header.Get("fleet-lock-protocol")), "fleet-lock-protocol header should be set")
+
+	params, err := api.ParseRequest(req.Body)
+	s.assert.NoError(err, "Request should have the correct format")
+
+	if s.Group != "" {
+		s.assert.Equal(s.Group, params.Client.Group, "Should have expected group")
+	} else {
+		s.assert.NotEmpty(params.Client.Group, "Should have group set")
+	}
+	if s.ID != "" {
+		s.assert.Equal(s.ID, params.Client.ID, "Should have expected id")
+	} else {
+		s.assert.NotEmpty(params.Client.ID, "Should have id set")
+	}
+
+	rw.WriteHeader(s.StatusCode)
+	b, err := json.MarshalIndent(api.FleetLockResponse{
+		Kind:  "ok",
+		Value: "Success",
+	}, "", "  ")
+	if !s.assert.NoError(err, "Error in fake server: failed to prepare response") {
+		return
+	}
+
+	_, err = rw.Write(b)
+	s.assert.NoError(err, "Error in fake server: failed to send response")
+}
+
+func (s *FakeServer) URL() string {
+	return s.server.URL
+}
+
+func (s *FakeServer) Close() {
+	if s != nil && s.server != nil {
+		s.server.Close()
+	}
+}

--- a/pkg/server/client/client.go
+++ b/pkg/server/client/client.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"net/http"
 	"sync"
+
+	"github.com/heathcliff26/fleetlock/pkg/api"
 )
 
 type FleetlockClient struct {
@@ -68,29 +70,29 @@ func (c *FleetlockClient) Release() error {
 	return fmt.Errorf("failed to release lock kind=\"%s\" reason=\"%s\"", res.Kind, res.Value)
 }
 
-func (c *FleetlockClient) doRequest(path string) (bool, FleetLockResponse, error) {
+func (c *FleetlockClient) doRequest(path string) (bool, api.FleetLockResponse, error) {
 	c.mutex.RLock()
 	defer c.mutex.RUnlock()
 
-	body, err := PrepareRequest(c.group, c.appID)
+	body, err := api.PrepareRequest(c.group, c.appID)
 	if err != nil {
-		return false, FleetLockResponse{}, fmt.Errorf("failed to prepare request body: %v", err)
+		return false, api.FleetLockResponse{}, fmt.Errorf("failed to prepare request body: %v", err)
 	}
 	req, err := http.NewRequest(http.MethodPost, c.url+path, body)
 	if err != nil {
-		return false, FleetLockResponse{}, fmt.Errorf("failed to create http post request: %v", err)
+		return false, api.FleetLockResponse{}, fmt.Errorf("failed to create http post request: %v", err)
 	}
 	req.Header.Set("fleet-lock-protocol", "true")
 	req.Header.Set("Content-Type", "application/json")
 
 	res, err := http.DefaultClient.Do(req)
 	if err != nil {
-		return false, FleetLockResponse{}, fmt.Errorf("failed to send request to server: %v", err)
+		return false, api.FleetLockResponse{}, fmt.Errorf("failed to send request to server: %v", err)
 	}
 
-	resBody, err := ParseResponse(res.Body)
+	resBody, err := api.ParseResponse(res.Body)
 	if err != nil {
-		return false, FleetLockResponse{}, fmt.Errorf("failed to prepare response body: %v", err)
+		return false, api.FleetLockResponse{}, fmt.Errorf("failed to prepare response body: %v", err)
 	}
 
 	return res.StatusCode == http.StatusOK, resBody, nil

--- a/pkg/server/client/client_test.go
+++ b/pkg/server/client/client_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/heathcliff26/fleetlock/pkg/api"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -138,13 +139,13 @@ func NewFakeServer(t *testing.T, statusCode int, path string) (*FleetlockClient,
 		assert.Equal(http.MethodPost, req.Method, "Should be POST request")
 		assert.Equal("true", strings.ToLower(req.Header.Get("fleet-lock-protocol")), "fleet-lock-protocol header should be set")
 
-		params, err := ParseRequest(req.Body)
+		params, err := api.ParseRequest(req.Body)
 		assert.NoError(err, "Request should have the correct format")
 		assert.Equal("testGroup", params.Client.Group, "Should have Group set")
 		assert.Equal("testID", params.Client.ID, "Should have ID set")
 
 		rw.WriteHeader(statusCode)
-		b, err := json.MarshalIndent(FleetLockResponse{
+		b, err := json.MarshalIndent(api.FleetLockResponse{
 			Kind:  "ok",
 			Value: "Success",
 		}, "", "  ")

--- a/pkg/server/client/utils.go
+++ b/pkg/server/client/utils.go
@@ -1,50 +1,12 @@
 package client
 
 import (
-	"bytes"
-	"encoding/json"
-	"io"
 	"log/slog"
 	"os"
 	"strings"
 
 	systemdutils "github.com/heathcliff26/fleetlock/pkg/systemd-utils"
 )
-
-// Parse an http request	 body and extract the parameters
-func ParseRequest(body io.ReadCloser) (FleetLockRequest, error) {
-	var res FleetLockRequest
-	err := json.NewDecoder(body).Decode(&res)
-	if err != nil {
-		return FleetLockRequest{}, err
-	}
-	return res, nil
-}
-
-// Parse an http response body and extract the parameters
-func ParseResponse(body io.ReadCloser) (FleetLockResponse, error) {
-	var res FleetLockResponse
-	err := json.NewDecoder(body).Decode(&res)
-	if err != nil {
-		return FleetLockResponse{}, err
-	}
-	return res, nil
-}
-
-// Create a new http request pody based on the provided parameters
-func PrepareRequest(group, id string) (io.Reader, error) {
-	req := FleetLockRequest{
-		Client: FleetLockRequestClient{
-			ID:    id,
-			Group: group,
-		},
-	}
-	body, err := json.Marshal(req)
-	if err != nil {
-		return nil, err
-	}
-	return bytes.NewReader(body), nil
-}
 
 // Read the machine-id from /etc/machine-id
 func GetMachineID() (string, error) {

--- a/pkg/server/responses.go
+++ b/pkg/server/responses.go
@@ -1,45 +1,45 @@
 package server
 
-import "github.com/heathcliff26/fleetlock/pkg/server/client"
+import "github.com/heathcliff26/fleetlock/pkg/api"
 
 var (
-	msgNotFound = client.FleetLockResponse{
+	msgNotFound = api.FleetLockResponse{
 		Kind:  "not_found",
 		Value: "The requested url is not found on this server",
 	}
-	msgWrongMethod = client.FleetLockResponse{
+	msgWrongMethod = api.FleetLockResponse{
 		Kind:  "bad_request",
 		Value: "Only accepts POST request",
 	}
-	msgMissingFleetLockHeader = client.FleetLockResponse{
+	msgMissingFleetLockHeader = api.FleetLockResponse{
 		Kind:  "missing_fleetlock_header",
 		Value: "The header fleet-lock-protocol must be set to true",
 	}
-	msgRequestParseFailed = client.FleetLockResponse{
+	msgRequestParseFailed = api.FleetLockResponse{
 		Kind:  "bad_request",
 		Value: "The request json could not be parsed",
 	}
-	msgInvalidGroupValue = client.FleetLockResponse{
+	msgInvalidGroupValue = api.FleetLockResponse{
 		Kind:  "bad_request",
 		Value: "The value of group is invalid or empty. It must conform to \"" + groupValidationPattern + "\"",
 	}
-	msgEmptyID = client.FleetLockResponse{
+	msgEmptyID = api.FleetLockResponse{
 		Kind:  "bad_request",
 		Value: "The value of id is empty",
 	}
-	msgUnexpectedError = client.FleetLockResponse{
+	msgUnexpectedError = api.FleetLockResponse{
 		Kind:  "error",
 		Value: "An unexpected error occured",
 	}
-	msgSuccess = client.FleetLockResponse{
+	msgSuccess = api.FleetLockResponse{
 		Kind:  "success",
 		Value: "The operation was succesfull",
 	}
-	msgSlotsFull = client.FleetLockResponse{
+	msgSlotsFull = api.FleetLockResponse{
 		Kind:  "all_slots_full",
 		Value: "Could not reserve a slot as all slots in the group are currently locked already",
 	}
-	msgWaitingForNodeDrain = client.FleetLockResponse{
+	msgWaitingForNodeDrain = api.FleetLockResponse{
 		Kind:  "waiting_for_node_drain",
 		Value: "The Slot has been reserved, but the node is not yet drained",
 	}

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -11,10 +11,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/heathcliff26/fleetlock/pkg/api"
 	"github.com/heathcliff26/fleetlock/pkg/k8s"
 	lockmanager "github.com/heathcliff26/fleetlock/pkg/lock-manager"
 	"github.com/heathcliff26/fleetlock/pkg/lock-manager/storage/memory"
-	"github.com/heathcliff26/fleetlock/pkg/server/client"
 	"github.com/stretchr/testify/assert"
 
 	v1 "k8s.io/api/core/v1"
@@ -297,19 +297,19 @@ func TestHealthCheck(t *testing.T) {
 	assert.Equal(http.StatusOK, rr.Result().StatusCode, "Health Check should return with 200")
 	assert.Equal("application/json", rr.Header().Get("Content-Type"), "Content type should be json")
 
-	var res client.FleetlockHealthResponse
+	var res api.FleetlockHealthResponse
 	err := json.NewDecoder(rr.Result().Body).Decode(&res)
 
 	assert.NoError(err, "Response should be parsable")
-	expectedRes := client.FleetlockHealthResponse{
+	expectedRes := api.FleetlockHealthResponse{
 		Status: "ok",
 	}
 	assert.Equal(expectedRes, res, "Response should match")
 }
 
-func newFleetlockRequest(group, id string) client.FleetLockRequest {
-	return client.FleetLockRequest{
-		Client: client.FleetLockRequestClient{
+func newFleetlockRequest(group, id string) api.FleetLockRequest {
+	return api.FleetLockRequest{
+		Client: api.FleetLockRequestClient{
 			ID:    id,
 			Group: group,
 		},
@@ -317,7 +317,7 @@ func newFleetlockRequest(group, id string) client.FleetLockRequest {
 }
 
 func createFleetLockRequest(group, id string) io.Reader {
-	body, _ := client.PrepareRequest(group, id)
+	body, _ := api.PrepareRequest(group, id)
 	return body
 }
 
@@ -329,10 +329,10 @@ func createRequest(target, group, id string) *http.Request {
 	return req
 }
 
-func parseResponse(rr *httptest.ResponseRecorder) (*http.Response, client.FleetLockResponse, error) {
+func parseResponse(rr *httptest.ResponseRecorder) (*http.Response, api.FleetLockResponse, error) {
 	res := rr.Result()
 
-	response, err := client.ParseResponse(res.Body)
+	response, err := api.ParseResponse(res.Body)
 
 	return res, response, err
 }


### PR DESCRIPTION
Move the fake server implementation into a separate package so it can be
consumed by other projects, for example kube-upgrade.

Move fleetlock api types to new package.