### PR TITLE
CI: Change e2e test runner to ubuntu-latest

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -79,9 +79,6 @@ jobs:
       - unit-tests
       - validate
     with:
-      # Need to use newer version of podman here
-      # TODO: Change back to latest when it tracks 24.04
-      os: ubuntu-24.04
       cmd: "make test-e2e"
 
   build-fleetctl:


### PR DESCRIPTION
Now that ubuntu-latest is 24.04, it can be tracked again.