### PR TITLE
unit-test: Use context scoped to current test

### DIFF
--- a/pkg/lock-manager/storage/kubernetes/storage_test.go
+++ b/pkg/lock-manager/storage/kubernetes/storage_test.go
@@ -1,7 +1,6 @@
 package kubernetes
 
 import (
-	"context"
 	"regexp"
 	"strconv"
 	"testing"
@@ -19,7 +18,7 @@ func TestConflictingGroupNames(t *testing.T) {
 			Name: nsName,
 		},
 	}
-	_, _ = client.CoreV1().Namespaces().Create(context.Background(), ns, metav1.CreateOptions{})
+	_, _ = client.CoreV1().Namespaces().Create(t.Context(), ns, metav1.CreateOptions{})
 
 	assert := assert.New(t)
 
@@ -39,6 +38,8 @@ func TestConflictingGroupNames(t *testing.T) {
 }
 
 func TestCompliantLeaseNames(t *testing.T) {
+	ctx := t.Context()
+
 	nsName := "fleetlock"
 	storage, client := NewKubernetesBackendWithFakeClient(nsName)
 	ns := &v1.Namespace{
@@ -46,14 +47,14 @@ func TestCompliantLeaseNames(t *testing.T) {
 			Name: nsName,
 		},
 	}
-	_, _ = client.CoreV1().Namespaces().Create(context.Background(), ns, metav1.CreateOptions{})
+	_, _ = client.CoreV1().Namespaces().Create(ctx, ns, metav1.CreateOptions{})
 
 	assert := assert.New(t)
 
 	err := storage.Reserve("default", "User")
 	assert.Nil(err, "Should reserve slot")
 
-	leases, _ := client.CoordinationV1().Leases(nsName).List(context.Background(), metav1.ListOptions{})
+	leases, _ := client.CoordinationV1().Leases(nsName).List(ctx, metav1.ListOptions{})
 
 	validationRegex := regexp.MustCompile("^[a-z0-9.-]+$")
 

--- a/pkg/lock-manager/storage/valkey/loadbalancer_test.go
+++ b/pkg/lock-manager/storage/valkey/loadbalancer_test.go
@@ -1,7 +1,6 @@
 package valkey
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -32,7 +31,7 @@ func TestLoadbalancer(t *testing.T) {
 			client.Close()
 		})
 
-		res, err := client.Do(context.Background(), client.B().Ping().Build()).ToString()
+		res, err := client.Do(t.Context(), client.B().Ping().Build()).ToString()
 
 		assert.Nil(err, "Can reach client")
 		assert.Equal("PONG", res, "Can reach client")
@@ -99,7 +98,7 @@ func TestLoadbalancer(t *testing.T) {
 			t.FailNow()
 		}
 
-		res, err := client.Do(context.Background(), client.B().Ping().Build()).ToString()
+		res, err := client.Do(t.Context(), client.B().Ping().Build()).ToString()
 
 		assert.NoError(err, "Should have failed over")
 		assert.Equal("PONG", res, "Should have failed over")
@@ -139,7 +138,7 @@ func TestLoadbalancer(t *testing.T) {
 			close(done)
 		}()
 		go func() {
-			_, err = client.Do(context.Background(), client.B().Ping().Build()).ToString()
+			_, err = client.Do(t.Context(), client.B().Ping().Build()).ToString()
 
 			assert.Error(err, "Call should fail")
 		}()

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -1,7 +1,6 @@
 package server
 
 import (
-	"context"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -228,7 +227,7 @@ func TestDrainNode(t *testing.T) {
 		lm:  lm,
 		k8s: k8s,
 	}
-	initTestCluster(fakeclient)
+	initTestCluster(t, fakeclient)
 
 	assert := assert.New(t)
 
@@ -268,7 +267,7 @@ func TestUncordonNode(t *testing.T) {
 		lm:  lm,
 		k8s: k8s,
 	}
-	initTestCluster(fakeclient)
+	initTestCluster(t, fakeclient)
 
 	assert := assert.New(t)
 
@@ -337,7 +336,7 @@ func parseResponse(rr *httptest.ResponseRecorder) (*http.Response, api.FleetLock
 	return res, response, err
 }
 
-func initTestCluster(client *fake.Clientset) {
+func initTestCluster(t *testing.T, client *fake.Clientset) {
 	testNode := &v1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: testNodeName,
@@ -346,12 +345,12 @@ func initTestCluster(client *fake.Clientset) {
 			NodeInfo: v1.NodeSystemInfo{MachineID: testNodeMachineID},
 		},
 	}
-	_, _ = client.CoreV1().Nodes().Create(context.Background(), testNode, metav1.CreateOptions{})
+	_, _ = client.CoreV1().Nodes().Create(t.Context(), testNode, metav1.CreateOptions{})
 
 	testNS := &v1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: testNamespace,
 		},
 	}
-	_, _ = client.CoreV1().Namespaces().Create(context.Background(), testNS, metav1.CreateOptions{})
+	_, _ = client.CoreV1().Namespaces().Create(t.Context(), testNS, metav1.CreateOptions{})
 }

--- a/tests/storage/kubernetes_test.go
+++ b/tests/storage/kubernetes_test.go
@@ -1,7 +1,6 @@
 package storage
 
 import (
-	"context"
 	"testing"
 
 	"github.com/heathcliff26/fleetlock/pkg/lock-manager/storage/kubernetes"
@@ -18,7 +17,7 @@ func TestKubernetesBackend(t *testing.T) {
 			Name: nsName,
 		},
 	}
-	_, _ = client.CoreV1().Namespaces().Create(context.Background(), ns, metav1.CreateOptions{})
+	_, _ = client.CoreV1().Namespaces().Create(t.Context(), ns, metav1.CreateOptions{})
 
 	RunLockManagerTestsuiteWithStorage(t, storage)
 }


### PR DESCRIPTION
Use the context provided by testing instead of an generic background context.