### PR TITLE
CI: Fix release workflow permissions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,6 +31,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      security-events: write
     with:
       tag: ${{ inputs.tag }}
       latest: ${{ inputs.latest }}


### PR DESCRIPTION
Update the release workflow to account for gosec action.

Signed-off-by: Heathcliff <heathcliff@heathcliff.eu>