### PR TITLE
CI: Allow release to create releases again

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,6 +19,11 @@ on:
         type: boolean
         default: false
         required: false
+      is-release:
+        description: "Release build"
+        type: boolean
+        default: false
+        required: false
   workflow_call:
     inputs:
       tag:
@@ -103,6 +108,7 @@ jobs:
       artifact: "bin/fleetctl-${{ matrix.arch }}"
       artifact-name: "fleetctl-${{ matrix.arch }}"
       cmd: "hack/build.sh fleetctl fleetctl-${{ matrix.arch }}"
+      is-release: ${{ inputs.is-release == true }}
     secrets: inherit
 
   build-fleetlock:
@@ -121,6 +127,7 @@ jobs:
       tag: "${{ inputs.tag == '' && 'rolling' || inputs.tag }}"
       tags: "${{ inputs.latest == true && 'type=raw,value=latest' || '' }}"
       dry-run: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' || inputs.dry-run == 'true' }}
+      release-version: "${{ inputs.is-release == true && inputs.tag || '' }}"
     secrets: inherit
 
   build-manifests:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -35,6 +35,7 @@ jobs:
     with:
       tag: ${{ inputs.tag }}
       latest: ${{ inputs.latest }}
+      is-release: true
     secrets: inherit
 
   release:


### PR DESCRIPTION
Adapt the release workflow to ensure that untagged branches still get build with the correct version information in the binary.