### PR TITLE
CI: Tag release to ensure correct version in binary

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,8 +26,18 @@ on:
         default: false
 
 jobs:
+  tag:
+    uses: heathcliff26/ci/.github/workflows/tag.yaml@main
+    permissions:
+      contents: write
+    with:
+      tag: ${{ inputs.tag }}
+      overwrite: ${{ inputs.update }}
+    secrets: inherit
+
   build:
     uses: ./.github/workflows/ci.yaml
+    needs: tag
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
Ensure the binary get's compiled with the correct version information by
creating the tag first.

Signed-off-by: Heathcliff <heathcliff@heathcliff.eu>