### PR TITLE
k8s: Evict self last

### DIFF
--- a/examples/deployment.yaml
+++ b/examples/deployment.yaml
@@ -204,6 +204,15 @@ spec:
           args:
             - "-c"
             - "/config/config.yaml"
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
           ports:
             - name: http
               containerPort: 8080

--- a/manifests/helm/templates/deployment.yaml
+++ b/manifests/helm/templates/deployment.yaml
@@ -43,6 +43,15 @@ spec:
           args:
             - "-c"
             - "/config/config.yaml"
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
           ports:
             - name: http
               containerPort: {{ (split ":" .Values.config.server.listen)._1 | default "8080" | int }}

--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -3,6 +3,7 @@ package k8s
 import (
 	"context"
 	"log/slog"
+	"os"
 	"time"
 
 	"github.com/heathcliff26/fleetlock/pkg/k8s/utils"
@@ -102,6 +103,8 @@ func (c *Client) drainNode(ctx context.Context, node string) error {
 	}
 
 	var returnError error
+	evictSelf := false
+	selfName, selfNamespace := os.Getenv("POD_NAME"), os.Getenv("POD_NAMESPACE")
 	for _, pod := range pods.Items {
 		// Skip mirror pods
 		if _, ok := pod.Annotations[v1.MirrorPodAnnotationKey]; ok {
@@ -113,17 +116,13 @@ func (c *Client) drainNode(ctx context.Context, node string) error {
 			continue
 		}
 
-		err = c.client.PolicyV1().Evictions(pod.GetNamespace()).Evict(ctx, &policyv1.Eviction{
-			TypeMeta: metav1.TypeMeta{
-				APIVersion: "policy/v1",
-				Kind:       "Eviction",
-			},
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      pod.GetName(),
-				Namespace: pod.GetNamespace(),
-			},
-			DeleteOptions: metav1.NewDeleteOptions(*pod.Spec.TerminationGracePeriodSeconds),
-		})
+		if pod.GetName() == selfName && pod.GetNamespace() == selfNamespace {
+			slog.Debug("Delaying evicting myself until all other pods are evicted", slog.String("node", node))
+			evictSelf = true
+			continue
+		}
+
+		err = c.evictPod(ctx, pod.GetName(), pod.GetNamespace(), pod.Spec.TerminationGracePeriodSeconds)
 		if err != nil {
 			slog.Info("Failed to evict pod", "err", err, slog.String("node", node), slog.String("pod", pod.GetName()), slog.String("namespace", pod.GetNamespace()))
 			returnError = NewErrorFailedToEvictAllPods()
@@ -144,6 +143,14 @@ func (c *Client) drainNode(ctx context.Context, node string) error {
 
 		if done {
 			break
+		}
+	}
+
+	if evictSelf {
+		err = c.evictPod(ctx, selfName, selfNamespace, utils.Pointer(int64(10)))
+		if err != nil {
+			slog.Info("Failed to evict myself", "err", err, slog.String("node", node), slog.String("pod", selfName), slog.String("namespace", selfNamespace))
+			returnError = NewErrorFailedToEvictAllPods()
 		}
 	}
 
@@ -201,4 +208,22 @@ func (c *Client) IsDrained(node string) (bool, error) {
 		return true, nil
 	}
 	return false, nil
+}
+
+// Evict a pod
+func (c *Client) evictPod(ctx context.Context, name, namespace string, terminationPeriod *int64) error {
+	eviction := &policyv1.Eviction{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "policy/v1",
+			Kind:       "Eviction",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+	}
+	if terminationPeriod != nil {
+		eviction.DeleteOptions = metav1.NewDeleteOptions(*terminationPeriod)
+	}
+	return c.client.PolicyV1().Evictions(namespace).Evict(ctx, eviction)
 }

--- a/pkg/k8s/client_test.go
+++ b/pkg/k8s/client_test.go
@@ -374,3 +374,15 @@ func TestIsDrained(t *testing.T) {
 		assert.True(res, "Should return true")
 	})
 }
+
+func TestEvictPod(t *testing.T) {
+	c, _ := initTestCluster(t)
+	assert := assert.New(t)
+
+	ctx := t.Context()
+
+	assert.NotPanics(func() {
+		err := c.evictPod(ctx, testPodName, testNamespace, nil)
+		assert.Nil(err, "Should not return an error")
+	}, "Should not panic on nil pointer")
+}


### PR DESCRIPTION
In order to avoid delays during node drain, ensure that the own pod is the last evicted from node.

Closes: #240