### PR TITLE
valkey/loadbalancer: Add delay in failover test

### DIFF
--- a/pkg/lock-manager/storage/valkey/loadbalancer_test.go
+++ b/pkg/lock-manager/storage/valkey/loadbalancer_test.go
@@ -64,6 +64,7 @@ func TestLoadbalancer(t *testing.T) {
 		assert.Equal(0, lb.selected, "Should have currently the first client selected")
 
 		mr1.Close()
+		time.Sleep(1 * time.Second) // Wait for mr1 to close
 
 		lb.HealthCheck()
 		require.Equal(1, lb.selected, "Should have failed over")


### PR DESCRIPTION
Ensure the miniredis instance closes before continuing test.

Fixes: #247