### PR TITLE
tests: Kill mysql container after test

### DIFF
--- a/tests/storage/mysql_test.go
+++ b/tests/storage/mysql_test.go
@@ -23,7 +23,7 @@ func TestMySQLBackend(t *testing.T) {
 		t.Fatalf("Failed to start test db: %v\n", err)
 	}
 	t.Cleanup(func() {
-		_ = utils.ExecCRI("stop", "fleetlock-mysql-db")
+		_ = utils.ExecCRI("kill", "fleetlock-mysql-db")
 	})
 
 	var storage *sql.SQLBackend


### PR DESCRIPTION
The container does not always stop during the 10s timeout when using stop. This causes the test to fail. As we do not care about any data in the container, use kill directly instead.

Signed-off-by: Heathcliff <heathcliff@heathcliff.eu>