### PR TITLE
valkey-loadbalancer: Do not start periodic check automatically

### DIFF
--- a/pkg/lock-manager/storage/valkey/loadbalancer.go
+++ b/pkg/lock-manager/storage/valkey/loadbalancer.go
@@ -49,7 +49,6 @@ func NewValkeyLoadbalancer(opt valkey.ClientOption) (valkey.Client, *loadbalance
 	}
 
 	lb.client = client
-	lb.PeriodicHealthCheck()
 
 	return lb.client, lb, nil
 }
@@ -137,4 +136,5 @@ func (lb *loadbalancer) DialCtxFn(ctx context.Context, _ string, dialer *net.Dia
 
 func (lb *loadbalancer) Close() {
 	lb.cancel()
+	lb.client.Close()
 }

--- a/pkg/lock-manager/storage/valkey/storage.go
+++ b/pkg/lock-manager/storage/valkey/storage.go
@@ -68,6 +68,9 @@ func NewValkeyBackend(cfg ValkeyConfig) (*ValkeyBackend, error) {
 		client, err = valkey.NewClient(opt)
 	case len(cfg.Addrs) > 1:
 		client, lb, err = NewValkeyLoadbalancer(opt)
+		if lb != nil {
+			lb.PeriodicHealthCheck()
+		}
 	default:
 		client, err = valkey.NewClient(opt)
 	}


### PR DESCRIPTION
To avoid race conditions during the unit-tests, require to start the periodic health check with a separate call.

Fixes: #259