### PR TITLE
unit-test: Add testcases for error exits

### DIFF
--- a/pkg/api/utils_test.go
+++ b/pkg/api/utils_test.go
@@ -1,0 +1,25 @@
+package api
+
+import (
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseResponse(t *testing.T) {
+	t.Run("Valid", func(t *testing.T) {
+		res, err := ParseResponse(io.NopCloser(strings.NewReader(`{"kind":"ok","value":"test"}`)))
+
+		assert.NoError(t, err)
+		assert.Equal(t, "ok", res.Kind)
+		assert.Equal(t, "test", res.Value)
+	})
+
+	t.Run("Invalid", func(t *testing.T) {
+		_, err := ParseResponse(io.NopCloser(strings.NewReader("not-json")))
+
+		assert.Error(t, err)
+	})
+}

--- a/pkg/fleetctl/appid_test.go
+++ b/pkg/fleetctl/appid_test.go
@@ -3,6 +3,7 @@ package fleetctl
 import (
 	"bytes"
 	"io"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -45,4 +46,14 @@ func TestIDCommand(t *testing.T) {
 	out, err = io.ReadAll(b)
 	require.NoError(err, "Output should be parsed without error")
 	assert.Equal("35ba2101ae3f4d45b96e9c51f461bbff\n", string(out), "Should output the correct app id")
+}
+
+func TestIDCommandExitError(t *testing.T) {
+	if os.Getenv("RUN_CRASH_TEST") == "1" {
+		cmd := NewIDCommand()
+		cmd.SetArgs([]string{"--" + flagNameMachineID, "invalid-not-hex"})
+		_ = cmd.Execute()
+		os.Exit(0)
+	}
+	execExitTest(t, "TestIDCommandExitError", true)
 }

--- a/pkg/fleetctl/lock_test.go
+++ b/pkg/fleetctl/lock_test.go
@@ -1,0 +1,57 @@
+package fleetctl
+
+import (
+	"bytes"
+	"net/http"
+	"os"
+	"testing"
+
+	"github.com/heathcliff26/fleetlock/pkg/fake"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewLockCommand(t *testing.T) {
+	cmd := NewLockCommand()
+
+	assert := assert.New(t)
+
+	assert.Equal("lock", cmd.Use)
+	assert.True(cmd.HasLocalFlags())
+}
+
+func TestLockCommand(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		srv := fake.NewFakeServer(t, http.StatusOK, "/v1/pre-reboot")
+		defer srv.Close()
+
+		cmd := NewLockCommand()
+		cmd.SetArgs([]string{srv.URL()})
+
+		b := &bytes.Buffer{}
+		cmd.SetOut(b)
+
+		err := cmd.Execute()
+
+		assert.NoError(t, err)
+		assert.Contains(t, b.String(), "Success")
+	})
+
+	t.Run("MissingArgs", func(t *testing.T) {
+		cmd := NewLockCommand()
+
+		err := cmd.Execute()
+
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "accepts 1 arg(s), received 0")
+	})
+}
+
+func TestLockCommandExitError(t *testing.T) {
+	if os.Getenv("RUN_CRASH_TEST") == "1" {
+		cmd := NewLockCommand()
+		cmd.SetArgs([]string{"http://127.0.0.1:1"})
+		_ = cmd.Execute()
+		os.Exit(0)
+	}
+	execExitTest(t, "TestLockCommandExitError", true)
+}

--- a/pkg/fleetctl/release_test.go
+++ b/pkg/fleetctl/release_test.go
@@ -1,0 +1,57 @@
+package fleetctl
+
+import (
+	"bytes"
+	"net/http"
+	"os"
+	"testing"
+
+	"github.com/heathcliff26/fleetlock/pkg/fake"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewReleaseCommand(t *testing.T) {
+	cmd := NewReleaseCommand()
+
+	assert := assert.New(t)
+
+	assert.Equal("release", cmd.Use)
+	assert.True(cmd.HasLocalFlags())
+}
+
+func TestReleaseCommand(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		srv := fake.NewFakeServer(t, http.StatusOK, "/v1/steady-state")
+		defer srv.Close()
+
+		cmd := NewReleaseCommand()
+		cmd.SetArgs([]string{srv.URL()})
+
+		b := &bytes.Buffer{}
+		cmd.SetOut(b)
+
+		err := cmd.Execute()
+
+		assert.NoError(t, err)
+		assert.Contains(t, b.String(), "Success")
+	})
+
+	t.Run("MissingArgs", func(t *testing.T) {
+		cmd := NewReleaseCommand()
+
+		err := cmd.Execute()
+
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "accepts 1 arg(s), received 0")
+	})
+}
+
+func TestReleaseCommandExitError(t *testing.T) {
+	if os.Getenv("RUN_CRASH_TEST") == "1" {
+		cmd := NewReleaseCommand()
+		cmd.SetArgs([]string{"http://127.0.0.1:1"})
+		_ = cmd.Execute()
+		os.Exit(0)
+	}
+	execExitTest(t, "TestReleaseCommandExitError", true)
+}

--- a/pkg/fleetctl/root_test.go
+++ b/pkg/fleetctl/root_test.go
@@ -1,6 +1,7 @@
 package fleetctl
 
 import (
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -10,4 +11,23 @@ func TestNewRootCommand(t *testing.T) {
 	cmd := NewRootCommand()
 
 	assert.Equal(t, Name, cmd.Use)
+}
+
+func TestExecute(t *testing.T) {
+	oldArgs := os.Args
+	defer func() { os.Args = oldArgs }()
+	os.Args = []string{"fleetctl", "--help"}
+
+	Execute()
+}
+
+func TestExecuteError(t *testing.T) {
+	if os.Getenv("RUN_CRASH_TEST") == "1" {
+		oldArgs := os.Args
+		defer func() { os.Args = oldArgs }()
+		os.Args = []string{"fleetctl", "invalid-command"}
+		Execute()
+		os.Exit(0)
+	}
+	execExitTest(t, "TestExecuteError", true)
 }

--- a/pkg/fleetctl/utils_test.go
+++ b/pkg/fleetctl/utils_test.go
@@ -1,6 +1,8 @@
 package fleetctl
 
 import (
+	"os"
+	"os/exec"
 	"testing"
 
 	"github.com/spf13/cobra"
@@ -90,4 +92,19 @@ func TestGetClientFromCMD(t *testing.T) {
 			}
 		})
 	}
+}
+
+func execExitTest(t *testing.T, test string, exitsError bool) {
+	cmd := exec.Command(os.Args[0], "-test.run="+test)
+	cmd.Env = append(os.Environ(), "RUN_CRASH_TEST=1")
+	err := cmd.Run()
+	if exitsError && err == nil {
+		t.Fatal("Process exited without error")
+	} else if !exitsError && err == nil {
+		return
+	}
+	if e, ok := err.(*exec.ExitError); ok && !e.Success() {
+		return
+	}
+	t.Fatalf("process ran with err %v, want exit status 1", err)
 }

--- a/pkg/fleetlock/root_test.go
+++ b/pkg/fleetlock/root_test.go
@@ -1,6 +1,8 @@
 package fleetlock
 
 import (
+	"os"
+	"os/exec"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -10,4 +12,63 @@ func TestNewRootCommand(t *testing.T) {
 	cmd := NewRootCommand()
 
 	assert.Equal(t, Name, cmd.Use)
+}
+
+func TestExecuteConfigLoadError(t *testing.T) {
+	if os.Getenv("RUN_CRASH_TEST") == "1" {
+		oldArgs := os.Args
+		defer func() { os.Args = oldArgs }()
+		os.Args = []string{"fleetlock", "-c", "/nonexistent/config.yaml"}
+		Execute()
+		os.Exit(0)
+	}
+	execExitTest(t, "TestExecuteConfigLoadError", true)
+}
+
+func TestExecuteK8sClientError(t *testing.T) {
+	if os.Getenv("RUN_CRASH_TEST") == "1" {
+		oldArgs := os.Args
+		defer func() { os.Args = oldArgs }()
+		os.Args = []string{"fleetlock", "-c", "testdata/kubernetes-draintimeout.yaml"}
+		Execute()
+		os.Exit(0)
+	}
+	execExitTest(t, "TestExecuteK8sClientError", true)
+}
+
+func TestExecuteServerCreationError(t *testing.T) {
+	if os.Getenv("RUN_CRASH_TEST") == "1" {
+		oldArgs := os.Args
+		defer func() { os.Args = oldArgs }()
+		os.Args = []string{"fleetlock", "-c", "testdata/invalid-storage.yaml"}
+		Execute()
+		os.Exit(0)
+	}
+	execExitTest(t, "TestExecuteServerCreationError", true)
+}
+
+func TestExecuteServerRunError(t *testing.T) {
+	if os.Getenv("RUN_CRASH_TEST") == "1" {
+		oldArgs := os.Args
+		defer func() { os.Args = oldArgs }()
+		os.Args = []string{"fleetlock", "-c", "testdata/ssl-missing-files.yaml"}
+		Execute()
+		os.Exit(0)
+	}
+	execExitTest(t, "TestExecuteServerRunError", true)
+}
+
+func execExitTest(t *testing.T, test string, exitsError bool) {
+	cmd := exec.Command(os.Args[0], "-test.run="+test)
+	cmd.Env = append(os.Environ(), "RUN_CRASH_TEST=1")
+	err := cmd.Run()
+	if exitsError && err == nil {
+		t.Fatal("Process exited without error")
+	} else if !exitsError && err == nil {
+		return
+	}
+	if e, ok := err.(*exec.ExitError); ok && !e.Success() {
+		return
+	}
+	t.Fatalf("process ran with err %v, want exit status 1", err)
 }

--- a/pkg/fleetlock/testdata/invalid-storage.yaml
+++ b/pkg/fleetlock/testdata/invalid-storage.yaml
@@ -1,0 +1,8 @@
+kubernetes:
+  drainTimeoutSeconds: 300
+server:
+  listen: ":8082"
+  storage:
+    type: "invalid-storage-type"
+groups:
+  default: {}

--- a/pkg/fleetlock/testdata/kubernetes-draintimeout.yaml
+++ b/pkg/fleetlock/testdata/kubernetes-draintimeout.yaml
@@ -1,0 +1,8 @@
+kubernetes:
+  drainTimeoutSeconds: 0
+server:
+  listen: ":8081"
+  storage:
+    type: memory
+groups:
+  default: {}

--- a/pkg/fleetlock/testdata/ssl-missing-files.yaml
+++ b/pkg/fleetlock/testdata/ssl-missing-files.yaml
@@ -1,0 +1,12 @@
+kubernetes:
+  drainTimeoutSeconds: 300
+server:
+  listen: ":8083"
+  ssl:
+    enabled: true
+    cert: "/nonexistent/cert.pem"
+    key: "/nonexistent/key.pem"
+  storage:
+    type: memory
+groups:
+  default: {}


### PR DESCRIPTION
Increase unit-tests by covering cases where the cli interface exits with error. Add additional miscelanous test for more coverage.