### PR TITLE
CI: Move manifest and helm to release workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -115,34 +115,3 @@ jobs:
       dry-run: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' || inputs.dry-run == 'true' }}
     secrets: inherit
 
-  build-manifests:
-    uses: heathcliff26/ci/.github/workflows/golang-build.yaml@main
-    if: ${{ github.event_name != 'pull_request' && github.event_name != 'merge_group' }}
-    permissions:
-      contents: read
-    needs:
-      - validate
-    with:
-      release: "${{ github.event_name == 'pull_request' && 'dev' || inputs.tag == '' && 'rolling' || inputs.tag }}"
-      artifact: "manifests/release/*.yaml"
-      artifact-name: "manifests"
-      cmd: "make manifests"
-      cache: false
-    secrets: inherit
-
-  push-helm:
-    uses: heathcliff26/ci/.github/workflows/push-helm-chart.yaml@main
-    if: ${{ inputs.tag != '' && inputs.tag != 'rolling' }}
-    permissions:
-      contents: read
-      packages: write
-    needs:
-      - lint
-      - unit-tests
-      - e2e
-      - build-fleetctl
-      - validate
-    with:
-      tag: "${{ inputs.tag }}"
-      dry-run: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' || inputs.dry-run == 'true' }}
-    secrets: inherit

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -37,7 +37,8 @@ jobs:
 
   build:
     uses: ./.github/workflows/ci.yaml
-    needs: tag
+    needs:
+      - tag
     permissions:
       contents: read
       packages: write
@@ -47,9 +48,36 @@ jobs:
       latest: ${{ inputs.latest }}
     secrets: inherit
 
+  build-manifests:
+    uses: heathcliff26/ci/.github/workflows/golang-build.yaml@main
+    needs:
+      - tag
+    permissions:
+      contents: read
+    with:
+      release: "${{ inputs.tag }}"
+      artifact: "manifests/release/*.yaml"
+      artifact-name: "manifests"
+      cmd: "make manifests"
+      cache: false
+    secrets: inherit
+
+  push-helm:
+    uses: heathcliff26/ci/.github/workflows/push-helm-chart.yaml@main
+    permissions:
+      contents: read
+      packages: write
+    needs:
+      - build
+      - build-manifests
+    with:
+      tag: "${{ inputs.tag }}"
+    secrets: inherit
+
   release:
     uses: heathcliff26/ci/.github/workflows/release.yaml@main
-    needs: build
+    needs:
+      - push-helm
     permissions:
       contents: write
     with:


### PR DESCRIPTION
Both are mostly skipped in CI except for release. Move them directly there instead.

Signed-off-by: Heathcliff <heathcliff@heathcliff.eu>