### PR TITLE
unit-test: Use synctest where useful

### DIFF
--- a/pkg/k8s/client_test.go
+++ b/pkg/k8s/client_test.go
@@ -3,6 +3,7 @@ package k8s
 import (
 	"context"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/heathcliff26/fleetlock/pkg/k8s/utils"
@@ -184,23 +185,25 @@ func TestDrainNode(t *testing.T) {
 		assert.Equal(time.Now().Round(time.Second), lease.Spec.AcquireTime.Round(time.Second), "AcquireTime should be now")
 	})
 	t.Run("DrainTimeout", func(t *testing.T) {
-		c, client := initTestCluster(t)
+		synctest.Test(t, func(t *testing.T) {
+			c, client := initTestCluster(t)
 
-		client.PrependReactor("create", "pods", func(action clienttesting.Action) (bool, runtime.Object, error) {
-			time.Sleep(5 * time.Second)
-			return false, nil, nil
+			client.PrependReactor("create", "pods", func(action clienttesting.Action) (bool, runtime.Object, error) {
+				synctest.Sleep(5 * time.Second)
+				return false, nil, nil
+			})
+
+			c.drainTimeoutSeconds = 1
+
+			err := c.DrainNode(testNodeName)
+
+			assert := assert.New(t)
+
+			assert.Equal(context.DeadlineExceeded, err, "Should exceed deadline")
+			lease, _ := client.CoordinationV1().Leases(testNamespace).Get(t.Context(), drainLeaseName(testNodeName), metav1.GetOptions{})
+			assert.Equal(leaseStateError, *lease.Spec.HolderIdentity, "Lease state should be error")
+			assert.Equal("1", lease.GetAnnotations()[leaseFailCounterName], "Lease fail counter should be 1")
 		})
-
-		c.drainTimeoutSeconds = 1
-
-		err := c.DrainNode(testNodeName)
-
-		assert := assert.New(t)
-
-		assert.Equal(context.DeadlineExceeded, err, "Should exceed deadline")
-		lease, _ := client.CoordinationV1().Leases(testNamespace).Get(t.Context(), drainLeaseName(testNodeName), metav1.GetOptions{})
-		assert.Equal(leaseStateError, *lease.Spec.HolderIdentity, "Lease state should be error")
-		assert.Equal("1", lease.GetAnnotations()[leaseFailCounterName], "Lease fail counter should be 1")
 	})
 }
 

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -9,6 +9,7 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/heathcliff26/fleetlock/pkg/api"
@@ -279,48 +280,52 @@ func TestHandleReleaseUncordonNodeError(t *testing.T) {
 }
 
 func TestDrainNode(t *testing.T) {
-	groups := lockmanager.NewDefaultGroups()
-	groups["default"] = lockmanager.GroupConfig{
-		Slots: 2,
-	}
-	lm := lockmanager.NewManagerWithStorage(groups, memory.NewMemoryBackend([]string{"default"}))
-	k8s, fakeclient := k8s.NewFakeClient()
-	s := &Server{
-		lm:  lm,
-		k8s: k8s,
-	}
-	initTestCluster(t, fakeclient)
+	synctest.Test(t, func(t *testing.T) {
+		groups := lockmanager.NewDefaultGroups()
+		groups["default"] = lockmanager.GroupConfig{
+			Slots: 2,
+		}
+		lm := lockmanager.NewManagerWithStorage(groups, memory.NewMemoryBackend([]string{"default"}))
+		k8s, fakeclient := k8s.NewFakeClient()
+		s := &Server{
+			lm:  lm,
+			k8s: k8s,
+		}
+		initTestCluster(t, fakeclient)
 
-	assert := assert.New(t)
+		assert := assert.New(t)
 
-	rr := httptest.NewRecorder()
-	params := newFleetlockRequest("default", "abcdef123456789")
-	s.handleReserve(rr, params)
-	res, response, err := parseResponse(rr)
+		// Drain non-existing node
+		rr := httptest.NewRecorder()
+		params := newFleetlockRequest("default", "abcdef123456789")
+		s.handleReserve(rr, params)
+		res, response, err := parseResponse(rr)
 
-	assert.NoError(err, "Requests should be handled without error")
-	assert.Equal(http.StatusOK, res.StatusCode, "Should return 200 OK when k8s node not found")
-	assert.Equal(msgSuccess, response, "Should return success message when k8s node not found")
+		assert.NoError(err, "Requests should be handled without error")
+		assert.Equal(http.StatusOK, res.StatusCode, "Should return 200 OK when k8s node not found")
+		assert.Equal(msgSuccess, response, "Should return success message when k8s node not found")
 
-	rr = httptest.NewRecorder()
-	params.Client.ID = testNodeZincatiID
-	s.handleReserve(rr, params)
-	res, response, err = parseResponse(rr)
+		// Drain existing node
+		rr = httptest.NewRecorder()
+		params.Client.ID = testNodeZincatiID
+		s.handleReserve(rr, params)
+		res, response, err = parseResponse(rr)
 
-	assert.NoError(err, "Requests should be handled without error")
-	assert.Equal(http.StatusAccepted, res.StatusCode, "Should return 202 Accepted when node is still being drained")
-	assert.Equal(msgWaitingForNodeDrain, response, "Should return message for node drain in progress")
+		assert.NoError(err, "Requests should be handled without error")
+		assert.Equal(http.StatusAccepted, res.StatusCode, "Should return 202 Accepted when node is still being drained")
+		assert.Equal(msgWaitingForNodeDrain, response, "Should return message for node drain in progress")
 
-	assert.Eventually(func() bool {
+		// Wait for the node to be drained
+		synctest.Sleep(time.Minute)
+
 		rr = httptest.NewRecorder()
 		s.handleReserve(rr, params)
 		res, response, err = parseResponse(rr)
-		return err == nil && res.StatusCode == http.StatusOK
-	}, 5*time.Second, time.Millisecond, "Node drain should eventually be completed")
 
-	assert.NoError(err, "Requests should be handled without error")
-	assert.Equal(http.StatusOK, res.StatusCode, "Should return 200 OK when node has been drained")
-	assert.Equal(msgSuccess, response, "Should return success message when node has been drained")
+		assert.NoError(err, "Requests should be handled without error")
+		assert.Equal(http.StatusOK, res.StatusCode, "Should return 200 OK when node has been drained")
+		assert.Equal(msgSuccess, response, "Should return success message when node has been drained")
+	})
 }
 
 func TestHandleReleaseSkipUncordonWithoutLock(t *testing.T) {


### PR DESCRIPTION
Simplify unit-tests with synctest.

Signed-off-by: Heathcliff <heathcliff@heathcliff.eu>